### PR TITLE
js: Add dir to import path when doing local Python imports; py: Custom error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pythonia",
   "author": "extremeheat",
-  "description": "Interop Node.js and Python and call Python APIs from Node.js",
+  "description": "Call and interop Python APIs from Node.js",
   "version": "0.1.1",
   "main": "./src/pythonia/index.js",
   "types": "./src/pythonia/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/extremeheat/JSPyBridge",
   "homepage": "https://github.com/PrismarineJS/bedrock-protocol#readme",
   "scripts": {
-    "install": "pip3 install black",
+    "prepare": "pip3 install black",
     "lint": "python3 -m black --line-length 100 src",
     "fix": "standard --fix",
     "test": "mocha"

--- a/src/JSPyBridge/errors.py
+++ b/src/JSPyBridge/errors.py
@@ -137,7 +137,7 @@ def processJsStacktrace(stack):
     for line in stacks:
         if not message_line:
             message_line = line
-        if (not "JSPyBride" in line) and (not found_main_line):
+        if (not "JSPyBridge" in line) and (not found_main_line):
             abs_path = re.search(r"\((.*):(\d+):(\d+)\)", line)
             file_path = re.search(r"(file:\/\/.*):(\d+):(\d+)", line)
             if abs_path or file_path:

--- a/src/JSPyBridge/errors.py
+++ b/src/JSPyBridge/errors.py
@@ -1,0 +1,172 @@
+import re
+
+
+class Chalk:
+    def red(self, text):
+        return "\033[91m" + text + "\033[0m"
+
+    def blue(self, text):
+        return "\033[94m" + text + "\033[0m"
+
+    def green(self, text):
+        return "\033[92m" + text + "\033[0m"
+
+    def yellow(self, text):
+        return "\033[93m" + text + "\033[0m"
+
+    def bold(self, text):
+        return "\033[1m" + text + "\033[0m"
+
+    def underline(self, text):
+        return "\033[4m" + text + "\033[0m"
+
+    def gray(self, text):
+        return "\033[2m" + text + "\033[0m"
+
+    def bgred(self, text):
+        return "\033[41m" + text + "\033[0m"
+
+    def darkred(self, text):
+        return "\033[31m" + text + "\033[0m"
+
+    def lightgray(self, text):
+        return "\033[37m" + text + "\033[0m"
+
+    def white(self, text):
+        return "\033[97m" + text + "\033[0m"
+
+
+chalk = Chalk()
+
+
+def format_line(line):
+    statements = [
+        "const ",
+        "await ",
+        "import ",
+        "let ",
+        "var ",
+        "async ",
+        "self ",
+        "def ",
+        "return ",
+        "from ",
+        "for ",
+        "raise ",
+        "try ",
+        "except ",
+        "catch ",
+        ":",
+        "\\(",
+        "\\)",
+        "\\+",
+        "\\-",
+        "\\*",
+        "=",
+    ]
+    secondary = ["{", "}", "'", " true", " false"]
+    for statement in statements:
+        exp = re.compile(statement, re.DOTALL)
+        line = re.sub(exp, chalk.red(statement.replace("\\", "")) + "", line)
+    for second in secondary:
+        exp = re.compile(second, re.DOTALL)
+        line = re.sub(exp, chalk.blue(second) + "", line)
+    return line
+
+
+def print_error(failedCall, jsErrorline, jsStackTrace, jsErrorMessage, pyErrorline, pyStacktrace):
+    lines = []
+    log = lambda *s: lines.append(" ".join(s))
+    log(
+        "☕",
+        chalk.bold(chalk.bgred(" JavaScript Error ")),
+        f"Call to '{failedCall.replace('~~', '')}' failed:",
+    )
+
+    for at, line in pyStacktrace:
+        if "JSPyBridge" in at or "IPython" in at:
+            continue
+        if not line:
+            log(" ", chalk.gray(at))
+        else:
+            log(chalk.gray(">"), format_line(line))
+            log(" ", chalk.gray(at))
+
+    log(chalk.gray(">"), format_line(pyErrorline))
+
+    log("\n... across the bridge ...\n")
+
+    for traceline in reversed(jsStackTrace):
+        log(" ", chalk.gray(traceline))
+
+    log(chalk.gray(">"), format_line(jsErrorline))
+    log("🌉", chalk.bold(jsErrorMessage))
+
+    return lines
+
+
+def processPyStacktrace(stack):
+    lines = []
+    error_line = ""
+    stacks = stack
+
+    for lin in stacks:
+        lin = lin.rstrip()
+        if lin.startswith("  File"):
+            lin, Code = lin.split("\n")
+            fname = lin.split('"')[1]
+            line = re.search(r"\, line (\d+)", lin).group(1)
+            at = re.search(r"\, in (.*)", lin)
+            if at:
+                at = at.group(1)
+            else:
+                at = "^"
+            lines.append([f"at {at} ({fname}:{line})", Code.strip()])
+        elif lin.strip():
+            error_line = lin.strip()
+
+    return error_line, lines
+
+
+def processJsStacktrace(stack):
+    lines = []
+    message_line = ""
+    error_line = ""
+    found_main_line = False
+    stacks = stack if (type(stack) is list) else stack.split("\n")
+    for line in stacks:
+        if not message_line:
+            message_line = line
+        if (not "JSPyBride" in line) and (not found_main_line):
+            abs_path = re.search(r"\((.*):(\d+):(\d+)\)", line)
+            file_path = re.search(r"(file:\/\/.*):(\d+):(\d+)", line)
+            if abs_path or file_path:
+                path = abs_path or file_path
+                fpath, errorline, char = path.groups()
+                if fpath.startswith("node:"):
+                    continue
+                with open(fpath, "r") as f:
+                    flines = f.readlines()
+                    error_line = flines[int(errorline) - 1].strip()
+                lines.append(line.strip())
+                found_main_line = True
+        elif found_main_line:
+            lines.append(line.strip())
+
+    return (error_line, message_line, lines) if error_line else None
+
+
+def getErrorMessage(failed_call, jsStackTrace, pyStacktrace):
+    try:
+        jse, jsm, jss = processJsStacktrace(jsStackTrace)
+        pye, pys = processPyStacktrace(pyStacktrace)
+
+        lines = print_error(failed_call, jse, jss, jsm, pye, pys)
+        return "\n".join(lines)
+    except Exception as e:
+        print("Error in exception handler")
+        import traceback
+
+        print(traceback.format_tb(e))
+        print(f"** JavaScript Stacktrace **{jsStackTrace}\n** Python Stacktrace **{pyStacktrace}")
+        return ""

--- a/src/JSPyBridge/proxy.py
+++ b/src/JSPyBridge/proxy.py
@@ -105,7 +105,9 @@ class Executor:
 
         res, barrier = self.loop.responses[callRespId]
         del self.loop.responses[callRespId]
+
         barrier.wait()
+
         if "error" in res:
             raise JavaScriptError(f"Call to '{attr}' failed:\n{res['error']}\n")
         return res["key"], res["val"]

--- a/src/JSPyBridge/proxy.py
+++ b/src/JSPyBridge/proxy.py
@@ -1,12 +1,55 @@
-import time, threading, json, os
-from . import config, json_patch
+import time, threading, json, sys, os, traceback
+from . import config, json_patch, errors
 
 debug = config.debug
 
 
+# Custom exception logic
 class JavaScriptError(Exception):
+    def __init__(self, call, jsStackTrace):
+        self.call = call
+        self.js = jsStackTrace
+
+
+# Fix for IPython as it blocks the exception hook
+# https://stackoverflow.com/a/28758396/11173996
+try:
+    __IPYTHON__
+    import IPython.core.interactiveshell.InteractiveShell
+
+    oldLogger = IPython.core.interactiveshell.InteractiveShell.showtraceback
+
+    def newLogger(*a, **kw):
+        ex_type, ex_inst, tb = sys.exc_info()
+        if ex_type is JavaScriptError:
+            pyStacktrace = traceback.format_tb(tb)
+            # The Python part of the stack trace is already printed by IPython
+            print(errors.getErrorMessage(ex_inst.call, ex_inst.js, pyStacktrace))
+        else:
+            oldLogger(*a, **kw)
+
+    IPython.core.interactiveshell.InteractiveShell.showtraceback = newLogger
+except NameError:
     pass
 
+orig_excepthook = sys.excepthook
+
+
+def error_catcher(error_type, error, error_traceback):
+    """
+    Catches JavaScript exceptions and prints them to the console.
+    """
+    if error_type is JavaScriptError:
+        pyStacktrace = traceback.format_tb(error_traceback)
+        jsStacktrace = error.js
+        message = errors.getErrorMessage(error.call, jsStacktrace, pyStacktrace)
+        print(message, file=sys.stderr)
+    else:
+        orig_excepthook(error_type, error, error_traceback)
+
+
+sys.excepthook = error_catcher
+# ====
 
 # This is the Executor, something that sits in the middle of the Bridge and is the interface for
 # Python to JavaScript. This is also used by the bridge to call Python from Node.js.
@@ -41,7 +84,7 @@ class Executor:
         del self.loop.responses[r]
         barrier.wait()
         if "error" in res:
-            raise JavaScriptError(f"Access to '{attr}' failed:\n{res['error']}\n")
+            raise JavaScriptError(attr, res["error"])
         return res
 
     def pcall(self, ffid, action, attr, args, timeout=10):
@@ -91,7 +134,7 @@ class Executor:
             del self.loop.responses[ffidRespId]
 
             if "error" in pre:
-                raise JavaScriptError(f"Call to '{attr}' failed:\n{pre['error']}\n")
+                raise JavaScriptError(attr, res["error"])
 
             for requestId in pre["val"]:
                 ffid = pre["val"][requestId]
@@ -109,7 +152,7 @@ class Executor:
         barrier.wait()
 
         if "error" in res:
-            raise JavaScriptError(f"Call to '{attr}' failed:\n{res['error']}\n")
+            raise JavaScriptError(attr, res["error"])
         return res["key"], res["val"]
 
     def getProp(self, ffid, method):

--- a/src/JSPyBridge/pyi.py
+++ b/src/JSPyBridge/pyi.py
@@ -34,6 +34,9 @@ class Iterate:
         yield self.what()
 
 
+fix_key = lambda key: key.replace("~~", "") if type(key) is str else key
+
+
 class PyInterface:
     m = {0: {"Iterate": Iterate}}
     # Things added to this dict are auto GC'ed
@@ -63,8 +66,13 @@ class PyInterface:
                 v = v[key]
             elif hasattr(v, str(key)):
                 v = getattr(v, str(key))
+            elif hasattr(v, "__getitem__"):
+                try:
+                    v = v[key]
+                except:
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
             else:
-                v = v[key]  # 🚨 If you get an error here, you called an undefined property
+                raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
         l = len(v)
         self.q(r, "num", l)
 
@@ -84,18 +92,28 @@ class PyInterface:
         if invoke:
             for key in keys:
                 t = getattr(v, str(key), None)
-                if t is None:
-                    v = v[key]  # 🚨 If you get an error here, you called an undefined property
-                else:
+                if t:
                     v = t
+                elif hasattr(v, "__getitem__"):
+                    try:
+                        v = v[key]
+                    except:
+                        raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
+                else:
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
         else:
             for key in keys:
                 if type(v) in (dict, tuple, list):
                     v = v[key]
                 elif hasattr(v, str(key)):
                     v = getattr(v, str(key))
+                elif hasattr(v, "__getitem__"):
+                    try:
+                        v = v[key]
+                    except:
+                        raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
                 else:
-                    v = v[key]  # 🚨 If you get an error here, you called an undefined property
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
 
         # Classes when called will return void, but we need to return
         # object to JS.
@@ -144,7 +162,10 @@ class PyInterface:
             elif hasattr(v, str(key)):
                 v = getattr(v, str(key))
             else:
-                v = v[key]  # 🚨 If you get an error here, you called an undefined property
+                try:
+                    v = v[key]
+                except:
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
         if type(v) in (dict, tuple, list, set):
             v[on] = val
         else:

--- a/src/pythonia/Bridge.js
+++ b/src/pythonia/Bridge.js
@@ -65,7 +65,7 @@ class PyClass {
     const [ffid, pyClass] = await bridge.makePyClass(this, name, {
       name,
       overriden: [...variables, ...members],
-      bases: [[sup.ffid, this.#superargs, this.#superkwargs]]
+      bases: this.#superclass ? [[sup.ffid, this.#superargs, this.#superkwargs]] : []
     })
     this.pyffid = ffid
 
@@ -80,7 +80,7 @@ class PyClass {
           if (members.has(prop)) return this[prop]
           else return pyClass[pname]
         },
-        set (target, prop, val) {
+        set: (target, prop, val) => {
           const pname = prop
           if (prop === 'parent') throw RangeError('illegal reserved property change')
           if (forceParent) return pyClass[pname] = val
@@ -243,7 +243,7 @@ class Bridge {
           // Python is the owner of the memory, we borrow a ref to it and once
           // we're done with it (GC'd), we can ask python to free it
           if (made[r] instanceof Promise) throw Error('You did not await a paramater when calling ' + stack.join('.'))
-          this.jsi.m[ffid] = made[r], ffid
+          this.jsi.m[ffid] = made[r]
           this.queueForCollection(ffid, made[r])
         }
         return true

--- a/src/pythonia/Bridge.py
+++ b/src/pythonia/Bridge.py
@@ -42,6 +42,9 @@ class Iterate:
         yield self.what()
 
 
+fix_key = lambda key: key.replace("~~", "") if type(key) is str else key
+
+
 class Bridge:
     m = {
         0: {
@@ -133,13 +136,13 @@ class Bridge:
                 v = v[key]
             elif hasattr(v, str(key)):
                 v = getattr(v, str(key))
-            elif hasattr(v, '__getitem__'):
+            elif hasattr(v, "__getitem__"):
                 try:
                     v = v[key]
                 except:
-                    raise LookupError(f"Property '{key.replace('~~', '') if type(key) is str else key}' does not exist on {repr(v)}")
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
             else:
-                raise LookupError(f"Property '{key.replace('~~', '') if type(key) is str else key}' does not exist on {repr(v)}")
+                raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
         l = len(v)
         self.q(r, "num", l)
 
@@ -161,26 +164,26 @@ class Bridge:
                 t = getattr(v, str(key), None)
                 if t:
                     v = t
-                elif hasattr(v, '__getitem__'):
+                elif hasattr(v, "__getitem__"):
                     try:
                         v = v[key]
                     except:
-                        raise LookupError(f"Property '{key.replace('~~', '') if type(key) is str else key}' does not exist on {repr(v)}")
+                        raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
                 else:
-                    raise LookupError(f"Property '{key.replace('~~', '') if type(key) is str else key}' does not exist on {repr(v)}")
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
         else:
             for key in keys:
                 if type(v) in (dict, tuple, list):
                     v = v[key]
                 elif hasattr(v, str(key)):
                     v = getattr(v, str(key))
-                elif hasattr(v, '__getitem__'):
+                elif hasattr(v, "__getitem__"):
                     try:
                         v = v[key]
                     except:
-                        raise LookupError(f"Property '{key.replace('~~', '') if type(key) is str else key}' does not exist on {repr(v)}")
+                        raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
                 else:
-                    raise LookupError(f"Property '{key.replace('~~', '')}' does not exist on {repr(v)}")
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
 
         # Classes when called will return void, but we need to return
         # object to JS.
@@ -232,7 +235,7 @@ class Bridge:
                 try:
                     v = v[key]
                 except:
-                    raise LookupError(f"Property '{key.replace('~~', '') if type(key) is str else key}' does not exist on {repr(v)}")
+                    raise LookupError(f"Property '{fix_key(key)}' does not exist on {repr(v)}")
         if type(v) in (dict, tuple, list, set):
             v[on] = val
         else:

--- a/src/pythonia/Bridge.py
+++ b/src/pythonia/Bridge.py
@@ -8,7 +8,9 @@ def python(method):
     return importlib.import_module(method, package=None)
 
 
-def fileImport(moduleName, absolutePath):
+def fileImport(moduleName, absolutePath, folderPath):
+    if folderPath not in sys.path:
+        sys.path.append(folderPath)
     spec = importlib.util.spec_from_file_location(moduleName, absolutePath)
     foo = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(foo)

--- a/src/pythonia/IpcPipeCom.js
+++ b/src/pythonia/IpcPipeCom.js
@@ -7,11 +7,11 @@ const log = process.env.DEBUG ? console.log : () => {}
 class StdioCom {
   constructor (ver = 3) {
     this.python = ver === 3 ? 'python3' : 'python2'
-    this.handlers = {}
     this.start()
   }
 
   start () {
+    this.handlers = {}
     this.proc = cp.spawn(this.python, [join(__dirname, 'interface.py')], { stdio: ['inherit', 'inherit', 'inherit', 'ipc'] })
     // BAD HACK: since the channel is not exposed, and we need to send JSON with a
     // custom serializer, we basically have two choices:
@@ -35,11 +35,11 @@ class StdioCom {
     this.proc.on('message', data => {
       this.recieve(data)
     })
-    this.proc.on('error', console.warn)
   }
 
   end () {
     this.proc.kill('SIGKILL')
+    this.proc = null
   }
 
   recieve (j) {

--- a/src/pythonia/StdioCom.js
+++ b/src/pythonia/StdioCom.js
@@ -6,11 +6,11 @@ const log = process.env.DEBUG ? console.log : () => {}
 class StdioCom {
   constructor (ver = 3) {
     this.python = ver === 3 ? 'python3' : 'python2'
-    this.handlers = {}
     this.start()
   }
 
   start () {
+    this.handlers = {}
     this.proc = cp.spawn(this.python, [join(__dirname, 'interface.py')], { stdio: ['pipe', 'inherit', 'pipe'] })
     this.proc.stderr.on('data', buf => {
       const data = String(buf)
@@ -28,11 +28,11 @@ class StdioCom {
         }
       }
     })
-    this.proc.on('error', console.warn)
   }
 
   end () {
     this.proc.kill()
+    this.proc = null
   }
 
   recieve (j) {

--- a/src/pythonia/errors.js
+++ b/src/pythonia/errors.js
@@ -78,11 +78,16 @@ function processJSStacktrace (stack, allowInternal) {
 }
 
 function getErrorMessage (failedCall, jsStacktrace, pyStacktrace) {
-  const [jse, jss] = processJSStacktrace(jsStacktrace) || processJSStacktrace(jsStacktrace, true)
-  const [pye, pys] = processPyStacktrace(pyStacktrace)
-
-  const lines = printError(failedCall, jse, jss, pye, pys)
-  return lines.join('\n')
+  try {
+    const [jse, jss] = processJSStacktrace(jsStacktrace) || processJSStacktrace(jsStacktrace, true)
+    const [pye, pys] = processPyStacktrace(pyStacktrace)
+  
+    const lines = printError(failedCall, jse, jss, pye, pys)
+    return lines.join('\n')
+  } catch (e) {
+    console.error(e)
+    console.log(`** Error in exception handler **\n** JavaScript Stacktrace **\n${jsStacktrace}\n** Python Stacktrace **\n${pyStacktrace}`)
+  }
 }
 
 module.exports = { getErrorMessage }

--- a/src/pythonia/errors.js
+++ b/src/pythonia/errors.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const fs = require('fs')
 
 function formatLine (line) {
-  const statements = ['const ', 'await ', 'import ', 'let ', 'var ', 'async ', 'self ', 'def ', 'return ', 'from ', 'for ', ':', '\\(', '\\)', '\\+', '\\-', '\\*', '=']
+  const statements = ['const ', 'await ', 'import ', 'let ', 'var ', 'async ', 'self ', 'def ', 'return ', 'from ', 'for ', 'raise ', 'try ', 'except ', 'catch ', ':', '\\(', '\\)', '\\+', '\\-', '\\*', '=']
   const secondary = ['{', '}', "'", ' true', ' false']
   for (const statement of statements) line = line.replace(new RegExp(statement, 'g'), chalk.red(statement.replace('\\', '')) + '')
   for (const second of secondary) line = line.replace(new RegExp(second, 'g'), chalk.blueBright(second) + '')
@@ -46,7 +46,7 @@ function processPyStacktrace (pyTrace) {
     } else if (lin.startsWith('    ')) {
       pyTraceLines[pyTraceLines.length - 1]?.push(lin.trim())
     } else if (lin.trim()) {
-      pyErrorLine = lin
+      pyErrorLine = lin.trim()
     }
   }
   return [pyErrorLine, pyTraceLines]
@@ -85,8 +85,9 @@ function getErrorMessage (failedCall, jsStacktrace, pyStacktrace) {
     const lines = printError(failedCall, jse, jss, pye, pys)
     return lines.join('\n')
   } catch (e) {
-    console.error(e)
-    console.log(`** Error in exception handler **\n** JavaScript Stacktrace **\n${jsStacktrace}\n** Python Stacktrace **\n${pyStacktrace}`)
+    console.error('** Error in exception handler **', e)
+    console.log(`** JavaScript Stacktrace **\n${jsStacktrace}\n** Python Stacktrace **\n${pyStacktrace}`)
+    return ''
   }
 }
 

--- a/src/pythonia/proxy.py
+++ b/src/pythonia/proxy.py
@@ -49,9 +49,9 @@ class Executor:
         """
         This function does a one-pass call to JavaScript. Since we assign the FFIDs, we do not
         need to send any preliminary call to JS. We can assign them ourselves.
-        
-        We simply iterate over the arguments, and for each of the non-primitive values, we 
-        create new FFIDs for them, then use them as a replacement for the non-primitive arg 
+
+        We simply iterate over the arguments, and for each of the non-primitive values, we
+        create new FFIDs for them, then use them as a replacement for the non-primitive arg
         objects. We can then send the request to JS and expect one response back.
         """
         self.ctr = 0
@@ -102,9 +102,9 @@ class Executor:
 
     def free(self, ffid):
         self.i += 1
-        try: 
+        try:
             l = self.queue(self.i, {"r": self.i, "action": "free", "args": [ffid]})
-        except ValueError: # Event loop is dead, no need for GC
+        except ValueError:  # Event loop is dead, no need for GC
             pass
 
     def new_ffid(self, for_object):

--- a/src/pythonia/proxy.py
+++ b/src/pythonia/proxy.py
@@ -29,12 +29,6 @@ class Executor:
             l = self.queue(r, {"r": r, "action": "inspect", "ffid": ffid})
         if action == "serialize":  # return JSON.stringify(obj[prop])
             l = self.queue(r, {"r": r, "action": "serialize", "ffid": ffid})
-        if action == "free":  # return JSON.stringify(obj[prop])
-            try:  # Event loop is dead, no need for GC
-                l = self.queue(r, {"r": r, "action": "free", "ffid": ffid})
-            except ValueError:
-                pass
-            return
         if action == "raw":
             # (not really a FFID, but request ID)
             r = ffid
@@ -54,10 +48,11 @@ class Executor:
     def pcall(self, ffid, action, attr, args, timeout=10):
         """
         This function does a one-pass call to JavaScript. Since we assign the FFIDs, we do not
-        need to send any preliminary call to JS. We simply iterate over the arguments, and for
-        the non-primitive values, we create new FFIDs for them, then use them as a replacement
-        for the non-primitive arg objects. We can then send the request to JS and expect one
-        response back.
+        need to send any preliminary call to JS. We can assign them ourselves.
+        
+        We simply iterate over the arguments, and for each of the non-primitive values, we 
+        create new FFIDs for them, then use them as a replacement for the non-primitive arg 
+        objects. We can then send the request to JS and expect one response back.
         """
         self.ctr = 0
         self.i += 1
@@ -101,12 +96,16 @@ class Executor:
         resp = self.pcall(ffid, "init", method, args)
         return resp
 
-    def inspect(self, ffid):
-        resp = self.ipc("inspect", ffid, "")
+    def inspect(self, ffid, mode):
+        resp = self.ipc("inspect", ffid, mode)
         return resp["val"]
 
     def free(self, ffid):
-        self.ipc("free", ffid, "")
+        self.i += 1
+        try: 
+            l = self.queue(self.i, {"r": self.i, "action": "free", "args": [ffid]})
+        except ValueError: # Event loop is dead, no need for GC
+            pass
 
     def new_ffid(self, for_object):
         self.loop.cur_ffid += 1
@@ -138,7 +137,7 @@ class Proxy(object):
         if methodType == "fn":
             return Proxy(self._exe, val, self.ffid, method)
         if methodType == "class":
-            return Proxy(self._exe, val, self.ffid, method, True)
+            return Proxy(self._exe, val, es6=True)
         if methodType == "obj":
             return Proxy(self._exe, val)
         if methodType == "inst":
@@ -197,10 +196,10 @@ class Proxy(object):
         return ser["val"]
 
     def __str__(self):
-        return self._exe.inspect(self.ffid)
+        return self._exe.inspect(self.ffid, "str")
 
     def __repr__(self):
-        return self._exe.inspect(self.ffid)
+        return self._exe.inspect(self.ffid, "repr")
 
     def __json__(self):
         return {"ffid": self.ffid}


### PR DESCRIPTION
* Sync bridges
* py: Custom error handling, make it friendlier/easier to debug
* js: Importing relative Python files now automatically adds the file's directory to the import path

Fixes
* js: Automatically restart Python processes on a new Python import, if python was exit()'ed earlier. Can happen in [tests](https://github.com/extremeheat/py2tsd/blob/8386e19213c35a231018e38df8d0f31bd438ec26/test/lib.test.js#L10).
* js: Fix relative imports on Windows not splitting \ correctly