### PR TITLE
py: Fix dep manager, rename project to "javascript"

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
-# pythonia (Bridge to access Python from JavaScript)
+## 0.2.1
+* Initial release of bridge to access JavaScript from Python
+* py: Fix issue with dependency installer
+* py: Fix issue with error handler and issues with IPython
 
 ## 0.2.0
 * Importing relative Python files now automatically adds the file's directory to the import path [#10](https://github.com/extremeheat/JSPyBridge/pull/10) 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,20 @@
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/extremeheat/jspybridge)
 
 
-Interoperate Node.js with Python. **Work in progress.**
-
-Requires Node.js 16 and Python 3.8 or newer.
+Interoperate Node.js with Python. **Work in progress.** Requires Node.js 16 and Python 3.8 or newer.
 
 ## Key Features
 
-* Async and sync function support
-* Native garbage collection
-* Callbacks
-* 🚦  Events
-* Exception handling
-* Iterator support
+* Ability to call async and sync functions and get object properties with a native feel
+* Built-in garbage collection
+* Bi-directional callbacks with arbitrary arguments
+* Iteration support
+* Object inspection allows you to easily `console.log` or `print()` any foreign objects
 
-#### Limitations / WIP
-
-* Standard input is not piped to bridge processes. Instead, listen to standard input then expose an API on the other side of the bridge recieve the data.
+#### Exclusive to python bridge for javascript
+* Python class extension and inheritance. See pytorch and tensorflow examples.
+#### Exclusive to javascript bridge for python
+* Native decorator-based event emitter support (javascript bridge)
 
 
 ## Basic usage example
@@ -28,19 +26,18 @@ See some examples [here](https://github.com/extremeheat/JSPyBridge/tree/master/e
 
 ### Access JavaScript from Python
 
-(Although the examples below use `javascript` import, please use `JSPyBridge` instead.)
 
 ```sh
-pip3 install git+https://github.com/extremeheat/jspybridge.git
+pip3 install javascript
 ```
 
 
 ```py
-from JSPyBridge import require, console
+from javascript import require, globalThis
 
 chalk, fs = require("chalk"), require("fs")
 
-console.log("Hello", chalk.red("world!"))
+print("Hello", chalk.red("world!"), "it's", globalThis.Date().toLocaleString())
 fs.writeFileSync("HelloWorld.txt", "hi!")
 ```
 
@@ -69,6 +66,30 @@ python.exit() // Make sure to exit Python in the end to allow node to exit. You 
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/extremeheat/jspybridge)
 
 Open in Gitpod link above, and open the examples folder.
+
+### Bridge feature comparison
+
+Unlike other bridges, you may notice you're not just writing Python code in JavaScript, or vice-versa. You can operate on objects
+on the other side of the bridge as if the objects existed on your side. This is achieved through real interop support: you can call
+callbacks, and do loss-less function calls with any arguments you like (with the exception of floating points percision of course).
+
+|  | python(ia) bridge | javascript bridge | [npm:python-bridge](https://www.npmjs.com/package/python-bridge) |
+|---|---|---|---|
+| Garbage collection | ✔ | ✔ | ❌ |
+| Class extension support | ✔ | Not built-in (rare use case), can be manually done with custom proxy | ❌ |
+| Passthrough stdin | ❌ (Standard input is not piped to bridge processes. Instead, listen to standard input then expose an API on the other side of the bridge recieve the data.) | ❌ | ✔ |
+| Passthrough stdout, stderr | ✔ | ✔ | ✔ |
+| Long-running sync calls | ✔ | ✔ | ✔ |
+| Long-running async calls | ❌ (need to manually create new thread) | ✔ (AsyncTask) | ❌ (need to manually create new thread) |
+| Callbacks | ✔ | ✔ | ❌ |
+| Call classes | ✔ | ✔ |  |
+| Iterators | ✔ | ✔ | ❌ |
+| Inline eval | ✔ | ❌ |  |
+| Dependency Management | ❌ | ✔ | ❌ |
+| Local File Imports | ✔ | ✔ | ❌ |
+| Error Management | ✔ | ✔ | ✔ |
+| Object inspection | ✔ | ✔ | ❌ |
+
 
 # Documentation
 

--- a/examples/python/cheerio.py
+++ b/examples/python/cheerio.py
@@ -1,4 +1,4 @@
-from JSPyBridge import require
+from javascript import require
 cheerio = require('cheerio');
 C = cheerio.load('<h2 class="title">Hello world</h2>')
 

--- a/examples/python/flyingsquid.py
+++ b/examples/python/flyingsquid.py
@@ -1,5 +1,5 @@
 import time
-from JSPyBridge import require
+from javascript import require
 mcServer = require('flying-squid')
 
 mcServer.createMCServer({

--- a/examples/python/mineflayer.py
+++ b/examples/python/mineflayer.py
@@ -1,4 +1,4 @@
-from JSPyBridge import require, On
+from javascript import require, On
 mineflayer = require('mineflayer')
 pathfinder = require('mineflayer-pathfinder')
 

--- a/examples/python/nbt.py
+++ b/examples/python/nbt.py
@@ -1,5 +1,5 @@
 # Named Binary Tag (NBT) serialization format
-from JSPyBridge import require, globalThis
+from javascript import require, globalThis
 JSON = globalThis.JSON
 nbt = require("prismarine-nbt", "latest")
 

--- a/examples/python/webserver.py
+++ b/examples/python/webserver.py
@@ -1,5 +1,5 @@
 import time
-from JSPyBridge import require
+from javascript import require
 http = require('http')
 
 def handler(this, req, res):

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "pythonia",
   "author": "extremeheat",
-  "description": "Call and interop Python APIs from Node.js",
-  "version": "0.2.0",
+  "description": "Bridge to call and interop Python APIs from Node.js",
+  "version": "0.2.1",
   "main": "./src/pythonia/index.js",
   "types": "./src/pythonia/index.d.ts",
   "repository": "https://github.com/extremeheat/JSPyBridge",
-  "homepage": "https://github.com/PrismarineJS/bedrock-protocol#readme",
+  "homepage": "https://github.com/extremeheat/JSPyBridge#readme",
   "scripts": {
     "prepare": "pip3 install black",
     "lint": "python3 -m black --line-length 100 src",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     # There are some restrictions on what makes a valid project name
     # specification here:
     # https://packaging.python.org/specifications/core-metadata/#name
-    name='JSPyBridge',  # Required
+    name='javascript',  # Required
 
     # Versions should comply with PEP 440:
     # https://www.python.org/dev/peps/pep-0440/
@@ -32,7 +32,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',  # Required
+    version='1!0.2.1',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
@@ -96,8 +96,6 @@ setup(
         # that you indicate you support Python 3. These classifiers are *not*
         # checked by 'pip install'. See instead 'python_requires' below.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
@@ -130,7 +128,7 @@ setup(
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. See
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.6, <4',
+    python_requires='>=3.8, <4',
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is

--- a/src/JSPyBridge/js/deps.js
+++ b/src/JSPyBridge/js/deps.js
@@ -19,7 +19,12 @@ class PackageManager {
    * Some utility methods to save, create, update the package.json
    */
   reload () {
-    this.installed = JSON.parse(fs.readFileSync(PACKAGE_PATH))
+    try {
+      this.installed = require(PACKAGE_PATH)
+    } catch (e) {
+      fs.writeFileSync(PACKAGE_PATH, '{\n\t"name": "js-modules",\n\t"description": "This folder holds the installed JS deps",\n\t"dependencies": {}\n}')
+      this.packages = require(PACKAGE_PATH)
+    }
   }
 
   save () {

--- a/src/JSPyBridge/proxy.py
+++ b/src/JSPyBridge/proxy.py
@@ -15,7 +15,7 @@ class JavaScriptError(Exception):
 # https://stackoverflow.com/a/28758396/11173996
 try:
     __IPYTHON__
-    import IPython.core.interactiveshell.InteractiveShell
+    import IPython.core.interactiveshell
 
     oldLogger = IPython.core.interactiveshell.InteractiveShell.showtraceback
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+from . import JSPyBridge


### PR DESCRIPTION
* Fix IPython error handling
* Fix dependency manager issues
* Update readme, package data for release. Rename project to just "javascript"
* Add new bridge feature comparison table