### PR TITLE
py: Handle errors when JS calls Python, handle more IO errors

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: CI
 
 on:
   push:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: npm-publish
+name: publish
 on:
   push:
     branches:
@@ -30,3 +30,19 @@ jobs:
         body: ${{ steps.publish.outputs.version }}
         draft: false
         prerelease: false
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      if: steps.publish.outputs.type != 'none'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,8 @@ on:
   push:
     branches:
       - master # Change this to your default branch
-    paths: # Run release job 
-      - 'setup.py'
+    # paths: # Run release job 
+    #   - 'setup.py'
 
 jobs:
   deploy:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include src/javascript/js/bridge.js
 include src/javascript/js/pyi.js
 include src/javascript/js/deps.js
+include src/javascript/js/errors.js

--- a/examples/python/mineflayer2.py
+++ b/examples/python/mineflayer2.py
@@ -27,7 +27,12 @@ host = sys.argv[1]
 port = sys.argv[2]
 username = sys.argv[3] if len(sys.argv) > 3 else "boat"
 
-bot = mineflayer.createBot({"host": host, "port": port, "username": username, "port": port})
+bot = mineflayer.createBot({
+    "host": host,
+    "port": port,
+    "username": username,
+    "port": port
+})
 
 Item = require("prismarine-item")(bot.version)
 
@@ -53,9 +58,9 @@ def handle(this, username, message, *args):
     elif message.startswith("spawn"):
         say_spawn()
     elif message.startswith("quit"):
-        quit(username)
+        quit_game(username)
     else:
-        bot.chat("That's nice 👍")
+        bot.chat("That's nice")
 
 
 def can_see(pos):
@@ -79,7 +84,6 @@ def say_position(username):
 def say_equipment(username):
     eq = bot.players[username].entity.equipment
     eqText = []
-    print("EQUIP", eq, eq[0])
     if eq[0]:
         eqText.append(f"holding a {eq[0].displayName}")
     if eq[1]:
@@ -106,7 +110,7 @@ def say_block_under():
     print(block)
 
 
-def quit(username):
+def quit_game(username):
     bot.quit(f"{username} told me to")
 
 
@@ -115,60 +119,60 @@ def say_nick():
 
 
 @On(bot, "whisper")
-def handle1(username, message, rawMessage):
+def whisper(this, username, message, rawMessage, *a):
     console.log(f"I received a message from {username}: {message}")
     bot.whisper(username, "I can tell secrets too.")
 
 
 @On(bot, "nonSpokenChat")
-def handle2(this, message):
+def nonSpokenChat(this, message):
     console.log(f"Non spoken chat: {message}")
 
 
 @On(bot, "login")
-def handle3(this):
+def login(this):
     bot.chat("Hi everyone!")
 
 
 @On(bot, "spawn")
-def handle4(this):
+def spawn(this):
     bot.chat("I spawned, watch out!")
 
 
 @On(bot, "spawnReset")
-def handle5(this, message):
+def spawnReset(this, message):
     bot.chat("Oh noez! My bed is broken.")
 
 
 @On(bot, "forcedMove")
-def handle6(this):
+def forcedMove(this):
     p = bot.entity.position
     bot.chat(f"I have been forced to move to {p.toString()}")
 
 
 @On(bot, "health")
-def handle7(this):
+def health(this):
     bot.chat(f"I have {bot.health} health and {bot.food} food")
 
 
 @On(bot, "death")
-def handle8(this):
+def death(this):
     bot.chat("I died x.x")
 
 
 @On(bot, "kicked")
-def handle9(this, reason, *a):
+def kicked(this, reason, *a):
     print("I was kicked", reason, a)
     console.log(f"I got kicked for {reason}")
 
 
 @On(bot, "time")
-def handle10(this):
+def time(this):
     bot.chat(f"Current time: " + str(bot.time.timeOfDay))
 
 
 @On(bot, "rain")
-def handle11(this):
+def rain(this):
     if bot.isRaining:
         bot.chat("It started raining")
     else:
@@ -176,53 +180,48 @@ def handle11(this):
 
 
 @On(bot, "noteHeard")
-def handle12(this, block, instrument, pitch):
+def noteHeard(this, block, instrument, pitch):
     bot.chat(f"Music for my ears! I just heard a {instrument.name}")
 
 
 @On(bot, "chestLidMove")
-def handle13(this, block, isOpen):
+def chestLidMove(this, block, isOpen, *a):
     action = "open" if isOpen else "close"
     bot.chat(f"Hey, did someone just {action} a chest?")
 
 
 @On(bot, "pistonMove")
-def handle14(this, block, isPulling, direction):
+def pistonMove(this, block, isPulling, direction):
     action = "pulling" if isPulling else "pushing"
     bot.chat(f"A piston is {action} near me, i can hear it.")
 
 
 @On(bot, "playerJoined")
-def handle15(this, player):
+def playerJoined(this, player):
     print("joined", player)
     if player["username"] != bot.username:
         bot.chat(f"Hello, {player['username']}! Welcome to the server.")
 
 
 @On(bot, "playerLeft")
-def handle16(this, player):
+def playerLeft(this, player):
     if player["username"] == bot.username:
         return
     bot.chat(f"Bye ${player.username}")
 
 
 @On(bot, "playerCollect")
-def handle17(this, collector, collected):
+def playerCollect(this, collector, collected):
     if collector.type == "player" and collected.type == "object":
         raw_item = collected.metadata[10]
-        ## does this work ??
-        print("item", Item)
         item = Item.fromNotch(raw_item)
-        header = (
-            ("I'm so jealous. " + collector.username)
-            if (collector.username != bot.username)
-            else "I "
-        )
+        header = ("I'm so jealous. " + collector.username) if (
+            collector.username != bot.username) else "I "
         bot.chat(f"{header} collected {item.count} {item.displayName}")
 
 
 @On(bot, "entitySpawn")
-def handle18(this, entity):
+def entitySpawn(this, entity):
     if entity.type == "mob":
         p = entity.position
         console.log(f"Look out! A {entity.mobType} spawned at {p.toString()}")
@@ -238,67 +237,67 @@ def handle18(this, entity):
 
 
 @On(bot, "entityHurt")
-def handle19(this, entity):
+def entityHurt(this, entity):
     if entity.type == "mob":
         bot.chat(f"Haha! The ${entity.mobType} got hurt!")
     elif entity.type == "player":
-        bot.chat(
-            f"Aww, poor {entity.username} got hurt. Maybe you shouldn't have a ping of {bot.players[entity.username].ping}"
-        )
+        if entity.username in bot.players:
+            ping = bot.players[entity.username].ping
+            bot.chat(f"Aww, poor {entity.username} got hurt. Maybe you shouldn't have a ping of {ping}")
 
 
 @On(bot, "entitySwingArm")
-def handle20(this, entity):
+def entitySwingArm(this, entity):
     bot.chat(f"{entity.username}, I see that your arm is working fine.")
 
 
 @On(bot, "entityCrouch")
-def handle21(this, entity):
+def entityCrouch(this, entity):
     bot.chat(f"${entity.username}: you so sneaky.")
 
 
 @On(bot, "entityUncrouch")
-def handle22(this, entity):
+def entityUncrouch(this, entity):
     bot.chat(f"{entity.username}: welcome back from the land of hunchbacks.")
 
 
 @On(bot, "entitySleep")
-def handle23(this, entity):
+def entitySleep(this, entity):
     bot.chat(f"Good night, {entity.username}")
 
 
 @On(bot, "entityWake")
-def handle24(this, entity):
+def entityWake(this, entity):
     bot.chat(f"Top of the morning, {entity.username}")
 
 
 @On(bot, "entityEat")
-def handle25(this, entity):
+def entityEat(this, entity):
     bot.chat(f"{entity.username}: OM NOM NOM NOMONOM. That's what you sound like.")
 
 
 @On(bot, "entityAttach")
-def handle26(this, entity, vehicle):
+def entityAttach(this, entity, vehicle):
     if entity.type == "player" and vehicle.type == "object":
         print(f"Sweet, {entity.username} is riding that {vehicle.objectType}")
 
 
 @On(bot, "entityDetach")
-def handle27(this, entity, vehicle):
+def entityDetach(this, entity, vehicle):
     if entity.type == "player" and vehicle.type == "object":
         print(f"Lame, {entity.username} stopped riding the {vehicle.objectType}")
 
 
 @On(bot, "entityEquipmentChange")
-def handle(this, entity):
+def entityEquipmentChange(this, entity):
     print("entityEquipmentChange", entity)
 
 
 @On(bot, "entityEffect")
-def handle28(this, entity, effect):
+def entityEffect(this, entity, effect):
     print("entityEffect", entity, effect)
 
 
 @On(bot, "entityEffectEnd")
-def handle29(this, entity, effect):
+def entityEffectEnd(this, entity, effect):
     print("entityEffectEnd", entity, effect)

--- a/examples/python/mineflayer2.py
+++ b/examples/python/mineflayer2.py
@@ -1,0 +1,304 @@
+# ==========================================================================
+# This example demonstrates how easy it is to create a bot
+# that sends chat messages whenever something interesting happens
+# on the server you are connected to.
+#
+# Below you can find a wide range of different events you can watch
+# but remember to check out the API documentation to find even more!
+#
+# Some events may be commented out because they are very frequent and
+# may flood the chat, feel free to check them out for other purposes though.
+#
+# This bot also replies to some specific chat messages so you can ask him
+# a few informations while you are in game.
+# ===========================================================================
+import sys, re
+from javascript import require, console, On, Once
+
+mineflayer = require("mineflayer", "latest")
+Vec3 = require("vec3").Vec3
+
+print(sys.argv)
+if len(sys.argv) < 3 or len(sys.argv) > 6:
+    console.log("Usage : node chatterbot.js <host> <port> [<name>]")
+    exit(1)
+
+host = sys.argv[1]
+port = sys.argv[2]
+username = sys.argv[3] if len(sys.argv) > 3 else "boat"
+
+bot = mineflayer.createBot({"host": host, "port": port, "username": username, "port": port})
+
+Item = require("prismarine-item")(bot.version)
+
+
+@On(bot, "chat")
+def handle(this, username, message, *args):
+    if username == bot.username:
+        return
+
+    if message.startswith("can see"):
+        # Extract x, y and z
+        # e.g. "can see 327 60 -120" or "can see 327, -23, -120"
+        try:
+            x, y, z = map(lambda v: int(v), message.split("see")[1].replace(",", " ").split())
+        except Exception:
+            bot.chat("Bad syntax")
+    elif message.startswith("pos"):
+        say_position(username)
+    elif message.startswith("wearing"):
+        say_equipment(username)
+    elif message.startswith("block"):
+        say_block_under()
+    elif message.startswith("spawn"):
+        say_spawn()
+    elif message.startswith("quit"):
+        quit(username)
+    else:
+        bot.chat("That's nice 👍")
+
+
+def can_see(pos):
+    block = bot.blockAt(pos)
+    canSee = bot.canSeeBlock(block)
+
+    if canSee:
+        bot.chat(f"I can see the block of {block.displayName} at {pos}")
+    else:
+        bot.chat(f"I can't see the block of {block.displayName} at {pos}")
+
+
+def say_position(username):
+    p = bot.entity.position
+    bot.chat(f"I am at {p.toString()}")
+    if username in bot.players:
+        p = bot.players[username].entity.position
+        bot.chat(f"You are at {p.toString()}")
+
+
+def say_equipment(username):
+    eq = bot.players[username].entity.equipment
+    eqText = []
+    print("EQUIP", eq, eq[0])
+    if eq[0]:
+        eqText.append(f"holding a {eq[0].displayName}")
+    if eq[1]:
+        eqText.append(f"wearing a {eq[1].displayName} on your feet")
+    if eq[2]:
+        eqText.append(f"wearing a {eq[2].displayName} on your legs")
+    if eq[3]:
+        eqText.append(f"wearing a {eq[3].displayName} on your torso")
+    if eq[4]:
+        eqText.append(f"wearing a {eq[4].displayName} on your head")
+    if len(eqText):
+        bot.chat(f"You are {', '.join(eqText)}.")
+    else:
+        bot.chat("You are naked!")
+
+
+def say_spawn():
+    bot.chat(f"Spawn is at {bot.spawnPoint.toString()}")
+
+
+def say_block_under():
+    block = bot.blockAt(bot.players[username].entity.position.offset(0, -1, 0))
+    bot.chat(f"Block under you is {block.displayName} in the {block.biome.name} biome")
+    print(block)
+
+
+def quit(username):
+    bot.quit(f"{username} told me to")
+
+
+def say_nick():
+    bot.chat(f"My name is {bot.player.displayName}")
+
+
+@On(bot, "whisper")
+def handle1(username, message, rawMessage):
+    console.log(f"I received a message from {username}: {message}")
+    bot.whisper(username, "I can tell secrets too.")
+
+
+@On(bot, "nonSpokenChat")
+def handle2(this, message):
+    console.log(f"Non spoken chat: {message}")
+
+
+@On(bot, "login")
+def handle3(this):
+    bot.chat("Hi everyone!")
+
+
+@On(bot, "spawn")
+def handle4(this):
+    bot.chat("I spawned, watch out!")
+
+
+@On(bot, "spawnReset")
+def handle5(this, message):
+    bot.chat("Oh noez! My bed is broken.")
+
+
+@On(bot, "forcedMove")
+def handle6(this):
+    p = bot.entity.position
+    bot.chat(f"I have been forced to move to {p.toString()}")
+
+
+@On(bot, "health")
+def handle7(this):
+    bot.chat(f"I have {bot.health} health and {bot.food} food")
+
+
+@On(bot, "death")
+def handle8(this):
+    bot.chat("I died x.x")
+
+
+@On(bot, "kicked")
+def handle9(this, reason, *a):
+    print("I was kicked", reason, a)
+    console.log(f"I got kicked for {reason}")
+
+
+@On(bot, "time")
+def handle10(this):
+    bot.chat(f"Current time: " + str(bot.time.timeOfDay))
+
+
+@On(bot, "rain")
+def handle11(this):
+    if bot.isRaining:
+        bot.chat("It started raining")
+    else:
+        bot.chat("It stopped raining")
+
+
+@On(bot, "noteHeard")
+def handle12(this, block, instrument, pitch):
+    bot.chat(f"Music for my ears! I just heard a {instrument.name}")
+
+
+@On(bot, "chestLidMove")
+def handle13(this, block, isOpen):
+    action = "open" if isOpen else "close"
+    bot.chat(f"Hey, did someone just {action} a chest?")
+
+
+@On(bot, "pistonMove")
+def handle14(this, block, isPulling, direction):
+    action = "pulling" if isPulling else "pushing"
+    bot.chat(f"A piston is {action} near me, i can hear it.")
+
+
+@On(bot, "playerJoined")
+def handle15(this, player):
+    print("joined", player)
+    if player["username"] != bot.username:
+        bot.chat(f"Hello, {player['username']}! Welcome to the server.")
+
+
+@On(bot, "playerLeft")
+def handle16(this, player):
+    if player["username"] == bot.username:
+        return
+    bot.chat(f"Bye ${player.username}")
+
+
+@On(bot, "playerCollect")
+def handle17(this, collector, collected):
+    if collector.type == "player" and collected.type == "object":
+        raw_item = collected.metadata[10]
+        ## does this work ??
+        print("item", Item)
+        item = Item.fromNotch(raw_item)
+        header = (
+            ("I'm so jealous. " + collector.username)
+            if (collector.username != bot.username)
+            else "I "
+        )
+        bot.chat(f"{header} collected {item.count} {item.displayName}")
+
+
+@On(bot, "entitySpawn")
+def handle18(this, entity):
+    if entity.type == "mob":
+        p = entity.position
+        console.log(f"Look out! A {entity.mobType} spawned at {p.toString()}")
+    elif entity.type == "player":
+        bot.chat(f"Look who decided to show up: {entity.username}")
+    elif entity.type == "object":
+        p = entity.position
+        console.log(f"There's a {entity.objectType} at {p.toString()}")
+    elif entity.type == "global":
+        bot.chat("Ooh lightning!")
+    elif entity.type == "orb":
+        bot.chat("Gimme dat exp orb!")
+
+
+@On(bot, "entityHurt")
+def handle19(this, entity):
+    if entity.type == "mob":
+        bot.chat(f"Haha! The ${entity.mobType} got hurt!")
+    elif entity.type == "player":
+        bot.chat(
+            f"Aww, poor {entity.username} got hurt. Maybe you shouldn't have a ping of {bot.players[entity.username].ping}"
+        )
+
+
+@On(bot, "entitySwingArm")
+def handle20(this, entity):
+    bot.chat(f"{entity.username}, I see that your arm is working fine.")
+
+
+@On(bot, "entityCrouch")
+def handle21(this, entity):
+    bot.chat(f"${entity.username}: you so sneaky.")
+
+
+@On(bot, "entityUncrouch")
+def handle22(this, entity):
+    bot.chat(f"{entity.username}: welcome back from the land of hunchbacks.")
+
+
+@On(bot, "entitySleep")
+def handle23(this, entity):
+    bot.chat(f"Good night, {entity.username}")
+
+
+@On(bot, "entityWake")
+def handle24(this, entity):
+    bot.chat(f"Top of the morning, {entity.username}")
+
+
+@On(bot, "entityEat")
+def handle25(this, entity):
+    bot.chat(f"{entity.username}: OM NOM NOM NOMONOM. That's what you sound like.")
+
+
+@On(bot, "entityAttach")
+def handle26(this, entity, vehicle):
+    if entity.type == "player" and vehicle.type == "object":
+        print(f"Sweet, {entity.username} is riding that {vehicle.objectType}")
+
+
+@On(bot, "entityDetach")
+def handle27(this, entity, vehicle):
+    if entity.type == "player" and vehicle.type == "object":
+        print(f"Lame, {entity.username} stopped riding the {vehicle.objectType}")
+
+
+@On(bot, "entityEquipmentChange")
+def handle(this, entity):
+    print("entityEquipmentChange", entity)
+
+
+@On(bot, "entityEffect")
+def handle28(this, entity, effect):
+    print("entityEffect", entity, effect)
+
+
+@On(bot, "entityEffectEnd")
+def handle29(this, entity, effect):
+    print("entityEffectEnd", entity, effect)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-from . import JSPyBridge

--- a/src/javascript/__main__.py
+++ b/src/javascript/__main__.py
@@ -1,16 +1,18 @@
 import os, sys, argparse, shutil
 
-parser = argparse.ArgumentParser(description='javascript (JSPyBridge) package manager. Use this to clear the internal package store.')
-parser.add_argument("clean", nargs='?', default=False)
+parser = argparse.ArgumentParser(
+    description="javascript (JSPyBridge) package manager. Use this to clear the internal package store."
+)
+parser.add_argument("clean", nargs="?", default=False)
 args = parser.parse_args()
 
 
 if args.clean:
     d = os.path.dirname(__file__)
-    nm = d + '/js/node_modules/'
-    nl = d + '/js/package-lock.json'
-    np = d + '/js/package.json'
-    print ('Deleting', nm, nl, np)
+    nm = d + "/js/node_modules/"
+    nl = d + "/js/package-lock.json"
+    np = d + "/js/package.json"
+    print("Deleting", nm, nl, np)
     try:
         shutil.rmtree(nm)
     except Exception:

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -63,8 +63,12 @@ def writeAll(objs):
         if not proc:
             sendQ.append(j.encode())
             continue
-        proc.stdin.write(j.encode())
-        proc.stdin.flush()
+        try:
+            proc.stdin.write(j.encode())
+            proc.stdin.flush()
+        except Exception:
+            kill_proc()
+            break
 
 
 stderr_lines = []
@@ -107,7 +111,13 @@ com_thread.start()
 
 def kill_proc():
     if proc:
-        proc.terminate()
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+def is_alive():
+    return proc.poll() is None
 
 
 # Make sure out child process is killed if the parent one is exiting

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -116,6 +116,7 @@ def kill_proc():
         except Exception:
             pass
 
+
 def is_alive():
     return proc.poll() is None
 

--- a/src/javascript/errors.py
+++ b/src/javascript/errors.py
@@ -1,4 +1,10 @@
-import re
+import re, sys
+
+class JavaScriptError(Exception):
+    def __init__(self, call, jsStackTrace, pyStacktrace=None):
+        self.call = call
+        self.js = jsStackTrace
+        self.py = pyStacktrace
 
 
 class Chalk:
@@ -175,3 +181,45 @@ def getErrorMessage(failed_call, jsStackTrace, pyStacktrace):
         pys = '\n'.join(pyStacktrace)
         print(f"** JavaScript Stacktrace **\n{jsStackTrace}\n** Python Stacktrace **\n{pys}")
         return ""
+
+# Custom exception logic
+
+# Fix for IPython as it blocks the exception hook
+# https://stackoverflow.com/a/28758396/11173996
+try:
+    __IPYTHON__
+    import IPython.core.interactiveshell
+
+    oldLogger = IPython.core.interactiveshell.InteractiveShell.showtraceback
+
+    def newLogger(*a, **kw):
+        ex_type, ex_inst, tb = sys.exc_info()
+        if ex_type is JavaScriptError:
+            pyStacktrace = traceback.format_tb(tb)
+            # The Python part of the stack trace is already printed by IPython
+            print(getErrorMessage(ex_inst.call, ex_inst.js, pyStacktrace))
+        else:
+            oldLogger(*a, **kw)
+
+    IPython.core.interactiveshell.InteractiveShell.showtraceback = newLogger
+except NameError:
+    pass
+
+orig_excepthook = sys.excepthook
+
+
+def error_catcher(error_type, error, error_traceback):
+    """
+    Catches JavaScript exceptions and prints them to the console.
+    """
+    if error_type is JavaScriptError:
+        pyStacktrace = traceback.format_tb(error_traceback)
+        jsStacktrace = error.js
+        message = errors.getErrorMessage(error.call, jsStacktrace, pyStacktrace)
+        print(message, file=sys.stderr)
+    else:
+        orig_excepthook(error_type, error, error_traceback)
+
+
+sys.excepthook = error_catcher
+# ====

--- a/src/javascript/errors.py
+++ b/src/javascript/errors.py
@@ -1,5 +1,6 @@
 import re, sys
 
+
 class JavaScriptError(Exception):
     def __init__(self, call, jsStackTrace, pyStacktrace=None):
         self.call = call
@@ -162,7 +163,7 @@ def processJsStacktrace(stack, allowInternal=False):
             lines.append(line.strip())
 
     if allowInternal and not error_line:
-        error_line = '^'
+        error_line = "^"
     return (error_line, message_line, lines) if error_line else None
 
 
@@ -178,9 +179,10 @@ def getErrorMessage(failed_call, jsStackTrace, pyStacktrace):
         import traceback
 
         print(e)
-        pys = '\n'.join(pyStacktrace)
+        pys = "\n".join(pyStacktrace)
         print(f"** JavaScript Stacktrace **\n{jsStackTrace}\n** Python Stacktrace **\n{pys}")
         return ""
+
 
 # Custom exception logic
 

--- a/src/javascript/errors.py
+++ b/src/javascript/errors.py
@@ -1,4 +1,4 @@
-import re, sys
+import re, sys, traceback
 
 
 class JavaScriptError(Exception):
@@ -24,6 +24,9 @@ class Chalk:
     def bold(self, text):
         return "\033[1m" + text + "\033[0m"
 
+    def italic(self, text):
+        return "\033[3m" + text + "\033[0m"
+
     def underline(self, text):
         return "\033[4m" + text + "\033[0m"
 
@@ -47,6 +50,8 @@ chalk = Chalk()
 
 
 def format_line(line):
+    if line.startswith("<") or line.startswith('\\'):
+        return line
     statements = [
         "const ",
         "await ",
@@ -120,7 +125,9 @@ def processPyStacktrace(stack):
     for lin in stacks:
         lin = lin.rstrip()
         if lin.startswith("  File"):
-            lin, Code = lin.split("\n")
+            tokens = lin.split("\n")
+            lin = tokens[0]
+            Code = tokens[1] if len(tokens) > 1 else chalk.italic('<via standard input>')
             fname = lin.split('"')[1]
             line = re.search(r"\, line (\d+)", lin).group(1)
             at = re.search(r"\, in (.*)", lin)
@@ -134,22 +141,28 @@ def processPyStacktrace(stack):
 
     return error_line, lines
 
+INTERNAL_FILES = ['bridge.js', 'pyi.js', 'errors.js', 'deps.js', 'test.js']
+def isInternal(file):
+    for f in INTERNAL_FILES:
+        if f in file: return True
+    return False
 
 def processJsStacktrace(stack, allowInternal=False):
     lines = []
     message_line = ""
     error_line = ""
     found_main_line = False
+    # print("Allow internal", allowInternal)
     stacks = stack if (type(stack) is list) else stack.split("\n")
     for line in stacks:
         if not message_line:
             message_line = line
         if allowInternal:
             lines.append(line.strip())
-        elif (not "javascript" in line) and (not found_main_line):
+        elif (not isInternal(line)) and (not found_main_line):
             abs_path = re.search(r"\((.*):(\d+):(\d+)\)", line)
             file_path = re.search(r"(file:\/\/.*):(\d+):(\d+)", line)
-            base_path = re.search(r"at (.*):(\d+):(\d+)$")
+            base_path = re.search(r"at (.*):(\d+):(\d+)$", line)
             if abs_path or file_path or base_path:
                 path = abs_path or file_path or base_path
                 fpath, errorline, char = path.groups()
@@ -218,7 +231,7 @@ def error_catcher(error_type, error, error_traceback):
     if error_type is JavaScriptError:
         pyStacktrace = traceback.format_tb(error_traceback)
         jsStacktrace = error.js
-        message = errors.getErrorMessage(error.call, jsStacktrace, pyStacktrace)
+        message = getErrorMessage(error.call, jsStacktrace, pyStacktrace)
         print(message, file=sys.stderr)
     else:
         orig_excepthook(error_type, error, error_traceback)

--- a/src/javascript/errors.py
+++ b/src/javascript/errors.py
@@ -149,8 +149,9 @@ def processJsStacktrace(stack, allowInternal=False):
         elif (not "javascript" in line) and (not found_main_line):
             abs_path = re.search(r"\((.*):(\d+):(\d+)\)", line)
             file_path = re.search(r"(file:\/\/.*):(\d+):(\d+)", line)
-            if abs_path or file_path:
-                path = abs_path or file_path
+            base_path = re.search(r"at (.*):(\d+):(\d+)$")
+            if abs_path or file_path or base_path:
+                path = abs_path or file_path or base_path
                 fpath, errorline, char = path.groups()
                 if fpath.startswith("node:"):
                     continue

--- a/src/javascript/events.py
+++ b/src/javascript/events.py
@@ -137,7 +137,8 @@ class EventLoop:
         if len(self.callbacks):
             config.debug("cannot exit because active callback", self.callbacks)
         while len(self.callbacks) and connection.is_alive():
-            time.sleep(0.3)
+            time.sleep(0.4)
+        time.sleep(0.4)  # Allow final IO
         self.callbackExecutor.running = False
         self.queue.put("exit")
 

--- a/src/javascript/events.py
+++ b/src/javascript/events.py
@@ -136,8 +136,8 @@ class EventLoop:
     def on_exit(self):
         if len(self.callbacks):
             config.debug("cannot exit because active callback", self.callbacks)
-        while len(self.callbacks):
-            time.sleep(0.2)
+        while len(self.callbacks) and connection.is_alive():
+            time.sleep(0.3)
         self.callbackExecutor.running = False
         self.queue.put("exit")
 

--- a/src/javascript/js/deps.js
+++ b/src/javascript/js/deps.js
@@ -12,7 +12,6 @@ const log = (...what) => console.log('\x1b[1m', ...what, '\x1b[0m')
 class PackageManager {
   constructor () {
     this.loadedPackages = []
-    this.reload()
   }
 
   /**

--- a/src/javascript/js/errors.js
+++ b/src/javascript/js/errors.js
@@ -1,0 +1,106 @@
+const supportsColors = true
+const chalk = {
+  boldRed: text => supportsColors ? `\x1b[1m\x1b[91m${text}\x1b[0m` : text,
+  blueBright: text => supportsColors ? `\x1b[91m${text}\x1b[0m` : text,
+  dim: text => supportsColors ? `\x1b[2m${text}\x1b[0m` : text,
+  red: text => supportsColors ? `\x1b[91m${text}\x1b[0m` : text,
+  bold: text => supportsColors ? `\x1b[1m${text}\x1b[0m` : text
+}
+const fs = require('fs')
+
+function formatLine (line) {
+  const statements = ['const ', 'await ', 'import ', 'let ', 'var ', 'async ', 'self ', 'def ', 'return ', 'from ', 'for ', 'with ', 'raise ', 'try ', 'except ', 'catch ', 'elif ', 'if ', ':', '\\(', '\\)', '\\+', '\\-', '\\*', '=']
+  const secondary = ['{', '}', "'", ' true', ' false']
+  for (const statement of statements) line = line.replace(new RegExp(statement, 'g'), chalk.red(statement.replace('\\', '')) + '')
+  for (const second of secondary) line = line.replace(new RegExp(second, 'g'), chalk.blueBright(second) + '')
+  return line
+}
+
+function printError (failedCall, jsErrorline, jsStacktrace, pyErrorline, pyStacktrace) {
+  const lines = []
+  const log = (...sections) => lines.push(sections.join(' '))
+  log('🐍', chalk.boldRed(' Python Error '), `JavaScript attempt to call '${failedCall.replace('~~', '') || 'some function'}' in Python failed:`)
+  log(chalk.dim('>'), formatLine(jsErrorline.trim()))
+
+  for (const traceline of jsStacktrace) {
+    log(' ', chalk.dim(traceline))
+  }
+
+  log('\n... across the bridge ...\n')
+
+  for (const [at, line] of pyStacktrace) {
+    if (at.includes('javascript')) continue
+    if (!line) {
+      log(' ', chalk.dim(at))
+    } else {
+      log(chalk.dim('>'), formatLine(line.trim()))
+      log(' ', chalk.dim(at))
+    }
+  }
+  log('🌉', chalk.bold(pyErrorline))
+  return lines
+}
+
+function processPyStacktrace (pyTrace) {
+  const pyTraceLines = []
+  let pyErrorLine = ''
+  for (const lin of pyTrace.split('\n')) {
+    if (lin.startsWith('  File')) {
+      const fname = lin.split('"')[1]
+      const line = lin.match(/, line (\d+)/)[1]
+      const at = lin.match(/, in (.*)/)?.[1] ?? '^'
+      pyTraceLines.push([`at ${at} (${fname}:${line})`])
+    } else if (lin.startsWith('    ')) {
+      pyTraceLines[pyTraceLines.length - 1]?.push(lin.trim())
+    } else if (lin.trim()) {
+      pyErrorLine = lin.trim()
+    }
+  }
+  return [pyErrorLine, pyTraceLines]
+}
+
+const INTERNAL_FILES = ['bridge.js', 'pyi.js', 'errors.js', 'deps.js', 'test.js']
+const isInternal = file => INTERNAL_FILES.find(k => file.includes(k))
+
+function processJSStacktrace (stack, allowInternal) {
+  const jsTraceLines = []
+  let jsErrorline
+  let foundMainLine = false
+  for (const line of stack.split('\n')) {
+    if (!(isInternal(line) && !allowInternal) && !foundMainLine) {
+      const absPath = line.match(/\((.*):(\d+):(\d+)\)/)
+      const filePath = line.match(/(file:\/\/.*):(\d+):(\d+)/)
+      const barePath = line.match(/at (.*):(\d+):(\d+)$/)
+      if (absPath || filePath || barePath) {
+        const path = absPath || filePath || barePath
+        const [fpath, errline, char] = path.slice(1)
+        if (fpath.startsWith('node:')) continue
+        const file = fs.readFileSync(fpath.startsWith('file:') ? new URL(fpath) : fpath, 'utf-8')
+        const flines = file.split('\n')
+        jsErrorline = flines[errline - 1]
+        jsTraceLines.push(line.trim())
+        foundMainLine = true
+      }
+    } else if (foundMainLine) {
+      jsTraceLines.push(line.trim())
+    }
+  }
+  return jsErrorline ? [jsErrorline, jsTraceLines] : null
+}
+
+function getErrorMessage (failedCall, jsStacktrace, pyStacktrace) {
+  console.log(failedCall, jsStacktrace, pyStacktrace)
+  try {
+    const [jse, jss] = processJSStacktrace(jsStacktrace) || processJSStacktrace(jsStacktrace, true)
+    const [pye, pys] = processPyStacktrace(pyStacktrace)
+
+    const lines = printError(failedCall, jse, jss, pye, pys)
+    return lines.join('\n')
+  } catch (e) {
+    console.error('** Error in exception handler **', e)
+    console.log(`** JavaScript Stacktrace **\n${jsStacktrace}\n** Python Stacktrace **\n${pyStacktrace}`)
+    return ''
+  }
+}
+
+module.exports = { getErrorMessage }

--- a/src/javascript/js/errors.js
+++ b/src/javascript/js/errors.js
@@ -71,8 +71,8 @@ function processJSStacktrace (stack, allowInternal) {
       const absPath = line.match(/\((.*):(\d+):(\d+)\)/)
       const filePath = line.match(/(file:\/\/.*):(\d+):(\d+)/)
       const barePath = line.match(/at (.*):(\d+):(\d+)$/)
-      if (absPath || filePath || barePath) {
-        const path = absPath || filePath || barePath
+      const path = absPath || filePath || barePath
+      if (path) {
         const [fpath, errline, char] = path.slice(1)
         if (fpath.startsWith('node:')) continue
         const file = fs.readFileSync(fpath.startsWith('file:') ? new URL(fpath) : fpath, 'utf-8')
@@ -89,7 +89,6 @@ function processJSStacktrace (stack, allowInternal) {
 }
 
 function getErrorMessage (failedCall, jsStacktrace, pyStacktrace) {
-  console.log(failedCall, jsStacktrace, pyStacktrace)
   try {
     const [jse, jss] = processJSStacktrace(jsStacktrace) || processJSStacktrace(jsStacktrace, true)
     const [pye, pys] = processPyStacktrace(pyStacktrace)

--- a/src/javascript/js/pyi.js
+++ b/src/javascript/js/pyi.js
@@ -91,9 +91,7 @@ class PyBridge {
     const resp = await waitFor(cb => this.request(req, cb), REQ_TIMEOUT, () => {
       throw new BridgeException(`Attempt to access '${stack.join('.')}' failed.`)
     })
-    if (resp.key === 'error') {
-      throw new PythonException(stack, resp.sig)
-    }
+    if (resp.key === 'error') throw new PythonException(stack, resp.sig)
     return resp.val
   }
 
@@ -197,6 +195,7 @@ class PyBridge {
   }
 
   makePyObject (ffid, inspectString) {
+    const self = this
     // "Intermediate" objects are returned while chaining. If the user tries to log
     // an Intermediate then we know they forgot to use await, as if they were to use
     // await, then() would be implicitly called where we wouldn't return a Proxy, but
@@ -242,7 +241,6 @@ class PyBridge {
             }
           }
           if (prop === Symbol.asyncIterator) {
-            const self = this
             return async function *iter () {
               const it = await self.call(0, ['Iterate'], [{ ffid }])
               while (true) {

--- a/src/javascript/proxy.py
+++ b/src/javascript/proxy.py
@@ -1,55 +1,8 @@
 import time, threading, json, sys, os, traceback
-from . import config, json_patch, errors
+from . import config, json_patch
+from .errors import JavaScriptError
 
 debug = config.debug
-
-
-# Custom exception logic
-class JavaScriptError(Exception):
-    def __init__(self, call, jsStackTrace):
-        self.call = call
-        self.js = jsStackTrace
-
-
-# Fix for IPython as it blocks the exception hook
-# https://stackoverflow.com/a/28758396/11173996
-try:
-    __IPYTHON__
-    import IPython.core.interactiveshell
-
-    oldLogger = IPython.core.interactiveshell.InteractiveShell.showtraceback
-
-    def newLogger(*a, **kw):
-        ex_type, ex_inst, tb = sys.exc_info()
-        if ex_type is JavaScriptError:
-            pyStacktrace = traceback.format_tb(tb)
-            # The Python part of the stack trace is already printed by IPython
-            print(errors.getErrorMessage(ex_inst.call, ex_inst.js, pyStacktrace))
-        else:
-            oldLogger(*a, **kw)
-
-    IPython.core.interactiveshell.InteractiveShell.showtraceback = newLogger
-except NameError:
-    pass
-
-orig_excepthook = sys.excepthook
-
-
-def error_catcher(error_type, error, error_traceback):
-    """
-    Catches JavaScript exceptions and prints them to the console.
-    """
-    if error_type is JavaScriptError:
-        pyStacktrace = traceback.format_tb(error_traceback)
-        jsStacktrace = error.js
-        message = errors.getErrorMessage(error.call, jsStacktrace, pyStacktrace)
-        print(message, file=sys.stderr)
-    else:
-        orig_excepthook(error_type, error, error_traceback)
-
-
-sys.excepthook = error_catcher
-# ====
 
 # This is the Executor, something that sits in the middle of the Bridge and is the interface for
 # Python to JavaScript. This is also used by the bridge to call Python from Node.js.

--- a/src/javascript/proxy.py
+++ b/src/javascript/proxy.py
@@ -216,6 +216,9 @@ class Proxy(object):
     def __setitem__(self, name, value):
         return self._exe.setProp(self.ffid, name, value)
 
+    def __contains__(self, key):
+        return True if self[key] is not None else False
+
     def valueOf(self):
         ser = self._exe.ipc("serialize", self.ffid, "")
         return ser["val"]

--- a/src/javascript/pyi.py
+++ b/src/javascript/pyi.py
@@ -4,6 +4,7 @@ import inspect, importlib, traceback
 import os, sys, json, types
 import socket
 from .proxy import Proxy
+from .errors import JavaScriptError, getErrorMessage
 from weakref import WeakValueDictionary
 
 

--- a/src/pythonia/Bridge.js
+++ b/src/pythonia/Bridge.js
@@ -264,8 +264,6 @@ class Bridge {
       case 'string':
       case 'int':
         return resp.val // Primitives don't need wrapping
-      case 'error':
-        throw new PythonException(stack, resp.sig)
       default: {
         const py = this.makePyObject(resp.val, resp.sig)
         this.queueForCollection(resp.val, py)

--- a/src/pythonia/errors.js
+++ b/src/pythonia/errors.js
@@ -26,7 +26,7 @@ function printError (failedCall, jsErrorline, jsStacktrace, pyErrorline, pyStack
     if (!line) {
       log(' ', chalk.dim(at))
     } else {
-      log(chalk.dim('>'), formatLine(line))
+      log(chalk.dim('>'), formatLine(line.trim()))
       log(' ', chalk.dim(at))
     }
   }
@@ -60,8 +60,9 @@ function processJSStacktrace (stack, allowInternal) {
     if (!(line.includes('pythonia') && !allowInternal) && !foundMainLine) {
       const absPath = line.match(/\((.*):(\d+):(\d+)\)/)
       const filePath = line.match(/(file:\/\/.*):(\d+):(\d+)/)
-      if (absPath || filePath) {
-        const path = absPath || filePath
+      const barePath = line.match(/at (.*):(\d+):(\d+)$/)
+      const path = absPath || filePath || barePath
+      if (path) {
         const [fpath, errline, char] = path.slice(1)
         if (fpath.startsWith('node:')) continue
         const file = fs.readFileSync(fpath.startsWith('file:') ? new URL(fpath) : fpath, 'utf-8')
@@ -81,7 +82,7 @@ function getErrorMessage (failedCall, jsStacktrace, pyStacktrace) {
   try {
     const [jse, jss] = processJSStacktrace(jsStacktrace) || processJSStacktrace(jsStacktrace, true)
     const [pye, pys] = processPyStacktrace(pyStacktrace)
-  
+
     const lines = printError(failedCall, jse, jss, pye, pys)
     return lines.join('\n')
   } catch (e) {

--- a/src/pythonia/interface.py
+++ b/src/pythonia/interface.py
@@ -19,6 +19,7 @@ class Ipc:
             # Quit if we are unable to write (is the parent process dead?)
             exit(1)
 
+
 ipc = Ipc()
 bridge = Bridge(ipc)
 

--- a/src/pythonia/interface.py
+++ b/src/pythonia/interface.py
@@ -9,12 +9,15 @@ apiin = apiout = None
 class Ipc:
     def queue(self, what):
         global apiout
-        if type(what) == str:
-            apiout.write(what + "\n")
-        else:
-            apiout.write(json.dumps(what) + "\n")
-        apiout.flush()
-
+        try:
+            if type(what) == str:
+                apiout.write(what + "\n")
+            else:
+                apiout.write(json.dumps(what) + "\n")
+            apiout.flush()
+        except Exception:
+            # Quit if we are unable to write (is the parent process dead?)
+            exit(1)
 
 ipc = Ipc()
 bridge = Bridge(ipc)

--- a/src/pythonia/proxy.py
+++ b/src/pythonia/proxy.py
@@ -191,6 +191,9 @@ class Proxy(object):
     def __setitem__(self, name, value):
         return self._exe.setProp(self.ffid, name, value)
 
+    def __contains__(self, key):
+        return True if self[key] is not None else False
+
     def valueOf(self):
         ser = self._exe.ipc("serialize", self.ffid, "")
         return ser["val"]


### PR DESCRIPTION
* py: errors when Python calls JS which calls Python back which returns an error is now handled
* py: do not block program exit if JS process is dead
* IO errors are suppressed. These errors are common when the other side of the bridge exists before the IO is finished on child process (e.g. crashing or Ctrl-C), no need to log them
* py: add new mineflayer example