### PR TITLE
py: Support Node.js 14+ or newer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 0.2.4
+* py: Support Node versions 14+
+
 ## 0.2.3
 * py: Add notebook and Google Colab support [#15](https://github.com/extremeheat/JSPyBridge/pull/15)
 * py: CLI now has a new --update flag to update internal, Node.js dependencies. Now use --clean to reset the package store.

--- a/src/javascript/__init__.py
+++ b/src/javascript/__init__.py
@@ -34,11 +34,10 @@ console = config.global_jsi.console
 globalThis = config.global_jsi.globalThis
 
 
-def AsyncTask(fn):
-    fn.is_async_task = True
-
-    def decor(start):
-        t = config.event_loop.startThread(fn)
+def AsyncTask(start=False):
+    def decor(fn):
+        fn.is_async_task = True
+        t = config.event_loop.newTaskThread(fn)
         if start:
             t.start()
 

--- a/src/javascript/__init__.py
+++ b/src/javascript/__init__.py
@@ -13,6 +13,9 @@ def init():
     config.global_jsi = proxy.Proxy(config.executor, 0)
     atexit.register(config.event_loop.on_exit)
 
+    if config.global_jsi.needsNodePatches():
+        config.node_emitter_patches = True
+
 
 init()
 
@@ -52,7 +55,17 @@ abort = config.event_loop.abortThread
 # you will not be able to off an emitter.
 def On(emitter, event):
     # print("On", emitter, event,onEvent)
-    def decor(fn):
+    def decor(_fn):
+        # Once Colab updates to Node 16, we can remove this.
+        # Here we need to manually add in the `this` argument for consistency in Node versions.
+        # In JS we could normally just bind `this` but there is no bind in Python.
+        if config.node_emitter_patches:
+            def handler(*args, **kwargs):
+                _fn(emitter, *args, **kwargs)
+            fn = handler
+        else:
+            fn = _fn
+
         emitter.on(event, fn)
         # We need to do some special things here. Because each Python object
         # on the JS side is unique, EventEmitter is unable to equality check
@@ -76,7 +89,10 @@ def Once(emitter, event):
         i = hash(fn)
 
         def handler(*args, **kwargs):
-            fn(*args, **kwargs)
+            if config.node_emitter_patches:
+                fn(emitter, *args, **kwargs)
+            else:
+                fn(*args, **kwargs)
             del config.event_loop.callbacks[i]
 
         emitter.once(event, handler)

--- a/src/javascript/config.py
+++ b/src/javascript/config.py
@@ -7,6 +7,8 @@ executor = None
 global_jsi = None
 # Currently this breaks GC
 fast_mode = False
+# Whether we need patches for legacy node versions
+node_emitter_patches = False
 
 
 if ("DEBUG" in os.environ) and ("jspybridge" in os.getenv("DEBUG")):

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -111,7 +111,7 @@ def com_io():
         )
     except Exception as e:
         print(
-            "--====--\t--====--\n\nBridge failed to spawn JS process!\n\nDo you have Node.js 15 or newer installed? Get it at https://nodejs.org/\n\n--====--\t--====--"
+            "--====--\t--====--\n\nBridge failed to spawn JS process!\n\nDo you have Node.js 16 or newer installed? Get it at https://nodejs.org/\n\n--====--\t--====--"
         )
         stop()
         raise e

--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -6,8 +6,6 @@ if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[
 /**
  * The JavaScript Interface for Python
  */
-
-
 const util = require('util')
 const { PyBridge } = require('./pyi')
 const { $require } = require('./deps')

--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -1,22 +1,12 @@
+if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[0]) < 14) {
+  console.error('Your node version is currently', process.versions.node)
+  console.error('Please update it to a version >= 14.x.x from https://nodejs.org/')
+  process.exit(1)
+}
 /**
  * The JavaScript Interface for Python
  */
 
-if (typeof process !== 'undefined') {
-  const [nodeVersion] = parseInt(process.versions.node.split('.'))
-  if ( nodeVersion < 14) {
-    console.error('Your node version is currently', process.versions.node)
-    console.error('Please update it to a version >= 14.x.x from https://nodejs.org/')
-    process.exit(1)
-  } else if (nodeVersion < 16) {
-    const emitter = require('events').EventEmitter
-    const oldEmit = oldEmit.prototype.emit
-    emitter.prototype.emit = function (...args) {
-      // We need to manually bind this pre-Node 16
-      oldEmit(this, ...args)
-    }
-  } 
-}
 
 const util = require('util')
 const { PyBridge } = require('./pyi')
@@ -63,7 +53,14 @@ class Bridge {
         console,
         require: $require,
         _require: require,
-        globalThis
+        globalThis,
+        needsNodePatches: () => {
+          const [major, minor] = process.versions.node.split('.')
+          if ((major == 14 && minor < 17) || (major == 15)) { // eslint-disable-line
+            return true
+          }
+          return false
+        }
       }
     }
     this.ipc = ipc

--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -1,11 +1,23 @@
-if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[0]) < 14) {
-  console.error('Your node version is currently', process.versions.node)
-  console.error('Please update it to a version >= 14.x.x from https://nodejs.org/')
-  process.exit(1)
-}
 /**
  * The JavaScript Interface for Python
  */
+
+if (typeof process !== 'undefined') {
+  const [nodeVersion] = parseInt(process.versions.node.split('.'))
+  if ( nodeVersion < 14) {
+    console.error('Your node version is currently', process.versions.node)
+    console.error('Please update it to a version >= 14.x.x from https://nodejs.org/')
+    process.exit(1)
+  } else if (nodeVersion < 16) {
+    const emitter = require('events').EventEmitter
+    const oldEmit = oldEmit.prototype.emit
+    emitter.prototype.emit = function (...args) {
+      // We need to manually bind this pre-Node 16
+      oldEmit(this, ...args)
+    }
+  } 
+}
+
 const util = require('util')
 const { PyBridge } = require('./pyi')
 const { $require } = require('./deps')


### PR DESCRIPTION
* py: Support node.js versions 14+ or newer, account for a PR in Node.js which alters the event emitter binding code 
* https://github.com/nodejs/node/pull/35931