### PR TITLE
Fixed console.log not working in Windows

### DIFF
--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -113,7 +113,7 @@ def readAll():
 def com_io():
     global proc, stdout_thread
     try:
-        if os.name == 'nt':
+        if os.name == 'nt' and 'idlelib.run' in sys.modules:
             proc = subprocess.Popen(
                 [NODE_BIN, dn + "/js/bridge.js"],
                 stdin=subprocess.PIPE,


### PR DESCRIPTION
console.log was only working if script was executed by IDLE,
Now the `subprocess.CREATE_NO_WINDOW` flag is only activated when running by IDLE to hide node console.