### PR TITLE
Fixing stdin String reading function that fails for long strings

### DIFF
--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -7,7 +7,6 @@ if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[
  * The JavaScript Interface for Python
  */
 const util = require('util')
-const os = require('os')
 const { PyBridge } = require('./pyi')
 const { $require } = require('./deps')
 const { once } = require('events')
@@ -269,7 +268,7 @@ let message = ''
 process.stdin.on('data', data => {
   const d = String(data)
   for (let i = 0; i < d.length; i++) {
-    if (d[i] === os.EOL) {
+    if (d[i] === '\n') {
       debug('py -> js', message)
       for (const line of message.split('\n')) {
         try { var j = JSON.parse(line) } catch (e) { continue } // eslint-disable-line

--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -7,6 +7,7 @@ if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[
  * The JavaScript Interface for Python
  */
 const util = require('util')
+const os = require('os')
 const { PyBridge } = require('./pyi')
 const { $require } = require('./deps')
 const { once } = require('events')
@@ -264,7 +265,7 @@ const ipc = {
 }
 
 const bridge = new Bridge(ipc)
-let message = '';
+let message = ''
 process.stdin.on('data', data => {
   const d = String(data)
   for (let i = 0; i < d.length; i++) {
@@ -278,28 +279,27 @@ process.stdin.on('data', data => {
           bridge.onMessage(j)
         }
       }
-      message = '';
+      message = ''
     } else {
-        message += d[i];
+      message += d[i]
     }
   }
 })
 
-
 // flush last line
 process.stdin.on('end', () => {
-    if (message.length > 0) {
-      debug('py -> js', message)
-      for (const line of message.split('\n')) {
+  if (message.length > 0) {
+    debug('py -> js', message)
+    for (const line of message.split('\n')) {
         try { var j = JSON.parse(line) } catch (e) { continue } // eslint-disable-line
-        if (j.c === 'pyi') {
-          handlers[j.r]?.(j)
-        } else {
-          bridge.onMessage(j)
-        }
+      if (j.c === 'pyi') {
+        handlers[j.r]?.(j)
+      } else {
+        bridge.onMessage(j)
       }
     }
-});
+  }
+})
 
 process.on('exit', () => {
   debug('** Node exiting')

--- a/src/javascript/js/pyi.js
+++ b/src/javascript/js/pyi.js
@@ -236,7 +236,7 @@ class PyBridge {
         if (typeof prop === 'symbol') {
           if (prop === Symbol.iterator) {
             // This is just for destructuring arrays
-            return function *iter () {
+            return function * iter () {
               for (let i = 0; i < 100; i++) {
                 const next = new Intermediate([...target.callstack, i])
                 yield new Proxy(next, handler)
@@ -245,7 +245,7 @@ class PyBridge {
             }
           }
           if (prop === Symbol.asyncIterator) {
-            return async function *iter () {
+            return async function * iter () {
               const it = await self.call(0, ['Iterate'], [{ ffid }])
               while (true) {
                 const val = await it.Next()

--- a/src/pythonia/Bridge.js
+++ b/src/pythonia/Bridge.js
@@ -358,7 +358,7 @@ class Bridge {
         if (typeof prop === 'symbol') {
           if (prop === Symbol.iterator) {
             // This is just for destructuring arrays
-            return function *iter () {
+            return function * iter () {
               for (let i = 0; i < 100; i++) {
                 const next = new Intermediate([...target.callstack, i])
                 yield new Proxy(next, handler)
@@ -367,7 +367,7 @@ class Bridge {
             }
           }
           if (prop === Symbol.asyncIterator) {
-            return async function *iter () {
+            return async function * iter () {
               const it = await self.call(0, ['Iterate'], [{ ffid }])
               while (true) {
                 const val = await it.Next()


### PR DESCRIPTION
When using the py -> js call, long strings were truncated. This commit fixes the issue by adding a buffer storing the data transmitted through stdin.