### PR TITLE
pythonia: Remove websocket comm

### DIFF
--- a/src/pythonia/index.js
+++ b/src/pythonia/index.js
@@ -4,11 +4,7 @@ if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[
   process.exit(1)
 }
 
-if (typeof window !== 'undefined') {
-  var { StdioCom } = require('./WebsocketCom')
-} else {
-  var { StdioCom } = process.platform === 'win32' ? require('./StdioCom') : require('./IpcPipeCom')
-}
+const { StdioCom } = process.platform === 'win32' ? require('./StdioCom') : require('./IpcPipeCom')
 
 const { dirname, join, resolve } = require('path')
 const { PyClass, Bridge } = require('./Bridge')


### PR DESCRIPTION
WebSocket support isn't functional, but we try to use this when a browser environment is detected (window != undefined). Since runtimes like Electron can declare window and still have access to node child_process, we can remove this check.

Fix #82