### PR TITLE
Add option to configure call timeout (REQ_TIMEOUT) from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,3 +321,5 @@ for await (const file of files) {
 * On the bridge to call JavaScript from Python, due to the limiatations of Python and cross-platform IPC, we currently communicate over standard error which means that JSON output in JS standard error can interfere with the bridge. The same issue exists on Windows with python. You are however very unlikely to have issues with this.
 
 * You can set the Node.js/Python binary paths by setting the `NODE_BIN` or `PYTHON_BIN` enviornment variables before importing the library. Otherwise, the `node` and `python3` or `python` binaries will be called relative to your PATH enviornment variable. 
+
+* Function calls will timeout after 100000 ms and throw a `BridgeException` error. That default value can be overridden by defining the new value of `REQ_TIMEOUT` in an environment variable.

--- a/src/javascript/js/pyi.js
+++ b/src/javascript/js/pyi.js
@@ -6,7 +6,8 @@ const util = require('util')
 if (typeof performance === 'undefined') var { performance } = require('perf_hooks')
 const log = () => { }
 const errors = require('./errors')
-const REQ_TIMEOUT = 100000
+// use REQ_TIMEOUT env var value if parseable as integer, otherwise default to 100000 (ms)
+const REQ_TIMEOUT = parseInt(process.env.REQ_TIMEOUT) || 100000
 
 class BridgeException extends Error {
   constructor (...a) {

--- a/src/pythonia/Bridge.js
+++ b/src/pythonia/Bridge.js
@@ -3,7 +3,8 @@ const { JSBridge } = require('./jsi')
 const errors = require('./errors')
 const log = process.env.DEBUG ? console.debug : () => {}
 // const log = console.log
-const REQ_TIMEOUT = 100000
+// use REQ_TIMEOUT env var value if parseable as integer, otherwise default to 100000 (ms)
+const REQ_TIMEOUT = parseInt(process.env.REQ_TIMEOUT) || 100000
 
 class BridgeException extends Error {
   constructor (...a) {


### PR DESCRIPTION
Add option to override default REQ_TIMEOUT value of 100000 ms using env vars. Configuring the timeout dynamically at runtime could be addressed in a future enhancement.

Resolves #57 