### PR TITLE
Allow to transfer binary data without serialization (CC #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,12 +312,14 @@ for await (const file of files) {
   - `.valueOf()` can be used on any JSON-serializable object, but may be very slow for big data.
   - `.blobValueOf()` can be used on any pipe-writeable object implementing the `length` property (e.g. `Buffer`). It can be massively faster by circumventing the JSON+UTF8 encode/decode layer, which is inept for large byte arrays.
 
-* You can set the Node.js/Python binary paths by setting the `NODE_BIN` or `PYTHON_BIN` enviornment variables before importing the library. Otherwise, the `node` and `python3` or `python` binaries will be called relative to your PATH enviornment variable. 
+* You can use custom Node.js/Python binary paths by setting the `NODE_BIN` or `PYTHON_BIN` enviornment variables before importing the library. Otherwise, the `node` and `python3` or `python` binaries will be called relative to your PATH enviornment variable. 
+
+* The inter-process communication can be inspected by setting the `DEBUG` env var to `jspybridge`.
 
 #### Limitations
 
 * The `ffid` keyword is reserved. You cannot use it in variable names, object keys or values as this is used to internlly track objects.
 
-* On the bridge to call JavaScript from Python, due to the limiatations of Python and cross-platform IPC, we currently communicate over standard error which means that specific output in JS standard error can interfere with the bridge. As of this writing, the prefices `{"r"` and `blob!` are reserved. The same issue exists on Windows with python. You are however very unlikely to have issues with this.
+* On the bridge to call JavaScript from Python, due to the limiatations of Python and cross-platform IPC, we currently communicate over standard error which means that specific output in JS standard error can interfere with the bridge (as of this writing, the prefices `{"r"` and `blob!` are reserved). A similar issue exists on Windows with Python. You are however very unlikely to have issues with this.
 
 * Function calls will timeout after 100000 ms and throw a `BridgeException` error. That default value can be overridden by defining the new value of `REQ_TIMEOUT` in an environment variable.

--- a/README.md
+++ b/README.md
@@ -301,24 +301,23 @@ for await (const file of files) {
 </details>
 
 ## Details
-* When doing a function call, any foreign objects will be sent to you as a reference. For example,
-  if you're in JavaScript and do a function call to Python that returns an array, you won't get a
-  JS array back, but you will get a reference to the Python array. You can still access the array
-  normally with the [] notation, as long as you use await. If you would like the bridge to turn
-  the foreign refrence to something native, you can request a primitive value by calling `.valueOf()`
-  on the Python array. This would give you a JS array. It works the same the other way around.
-* The above behavior makes it very fast to pipe data from one function onto another, avoiding costly
-  conversions.
-* This above behavior is not present for callbacks and function parameters. The bridge will try to
-  serialize what it can, and will give you a foreign reference if it's unable to serialize something.
-  So if you pass a JS object, you'll get a Python dict, but if the dict contains something like a class,
-  you'll get a reference in its place.
 
-#### Notable details
+* When doing a function call, any returned foreign objects will be sent to you as a reference. For example, if you're in JavaScript and do a function call to Python that returns an array, you won't get a JS array back, but you will get a reference to the Python array. You can still access the array normally with the [] notation, as long as you use await.
 
-* The `ffid` keyword is reserved. You cannot use it in variable names, object keys or values as this is used to internlly track objects.
-* On the bridge to call JavaScript from Python, due to the limiatations of Python and cross-platform IPC, we currently communicate over standard error which means that JSON output in JS standard error can interfere with the bridge. The same issue exists on Windows with python. You are however very unlikely to have issues with this.
+* This behavior makes it very fast to pass objects directly between same-language functions, avoiding costly cross-language data transfers.
+
+* However, this does not apply with callbacks or non-native function input parameters. The bridge will try to serialize what it can, and will give you a foreign reference if it's unable to serialize something. So if you pass a JS object, you'll get a Python dict, but if the dict contains something like a class, you'll get a reference in its place.
+
+* If you would like the bridge to turn a foreign reference to something native, you can use `.valueOf()` to transfer an object via JSON serialization, or `.blobValueOf()` to write an object into the communication pipe directly.
+  - `.valueOf()` can be used on any JSON-serializable object, but may be very slow for big data.
+  - `.blobValueOf()` can be used on any pipe-writeable object implementing the `length` property (e.g. `Buffer`). It can be massively faster by circumventing the JSON+UTF8 encode/decode layer, which is inept for large byte arrays.
 
 * You can set the Node.js/Python binary paths by setting the `NODE_BIN` or `PYTHON_BIN` enviornment variables before importing the library. Otherwise, the `node` and `python3` or `python` binaries will be called relative to your PATH enviornment variable. 
+
+#### Limitations
+
+* The `ffid` keyword is reserved. You cannot use it in variable names, object keys or values as this is used to internlly track objects.
+
+* On the bridge to call JavaScript from Python, due to the limiatations of Python and cross-platform IPC, we currently communicate over standard error which means that specific output in JS standard error can interfere with the bridge. As of this writing, the prefices `{"r"` and `blob!` are reserved. The same issue exists on Windows with python. You are however very unlikely to have issues with this.
 
 * Function calls will timeout after 100000 ms and throw a `BridgeException` error. That default value can be overridden by defining the new value of `REQ_TIMEOUT` in an environment variable.

--- a/examples/python/pdfjs.py
+++ b/examples/python/pdfjs.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2023 mara004 aka geisserml <geisserml@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0 OR Apache-2.0
+
+# See also https://gist.github.com/mara004/87276da4f8be31c80c38036c6ab667d7
+
+# Py-Depends: Pillow, JsPyBridge itself
+# Js-Depends: pdfjs-dist, canvas
+# Use `python -m pip install` and `python -m javascript --install`
+
+import argparse
+from pathlib import Path
+import PIL.Image
+import javascript
+
+# NOTE canvas must be the build pdfjs is linked against, otherwise it'll fail with type error
+pdfjs = javascript.require("pdfjs-dist")
+libcanvas = javascript.require("canvas")
+jsfs = javascript.require("fs")
+
+
+def render_pdf(inpath, outdir, scale=4):
+    
+    pdf = pdfjs.getDocument(str(inpath)).promise
+    n_pages = pdf.numPages
+    n_digits = len(str(n_pages))
+    
+    for i in range(1, n_pages+1):
+        
+        page = pdf.getPage(i)
+        viewport = page.getViewport({"scale": scale})
+        w, h = int(viewport.width), int(viewport.height)
+        
+        canvas = libcanvas.createCanvas(w, h)
+        context = canvas.getContext("2d")
+        page.render({"canvasContext": context, "viewport": viewport}).promise
+        
+        js_buffer = canvas.toBuffer("raw")
+        py_buffer = js_buffer.blobValueOf()
+        
+        pil_image = PIL.Image.frombuffer("RGBX", (w, h), py_buffer, "raw", "BGRX", 0, 1)
+        pil_image.save(outdir / f"out_{i:0{n_digits}d}.jpg")
+    
+    pdf.destroy()
+
+
+def main():
+    
+    parser = argparse.ArgumentParser(
+        description="Render a PDF file with Mozilla pdf.js via JsPyBridge",
+    )
+    ResolvedPath = lambda p: Path(p).expanduser().resolve()
+    parser.add_argument("inpath", type=ResolvedPath)
+    parser.add_argument("--outdir", "-o", type=ResolvedPath)
+    parser.add_argument("--scale", type=float)
+    
+    args = parser.parse_args()
+    if not args.outdir.exists():
+        args.outdir.mkdir(parents=True, exist_ok=True)
+    
+    render_pdf(args.inpath, args.outdir, scale=args.scale)
+
+
+main()

--- a/examples/python/pdfjs.py
+++ b/examples/python/pdfjs.py
@@ -15,10 +15,9 @@ import javascript
 # NOTE canvas must be the build pdfjs is linked against, otherwise it'll fail with type error
 pdfjs = javascript.require("pdfjs-dist")
 libcanvas = javascript.require("canvas")
-jsfs = javascript.require("fs")
 
 
-def render_pdf(inpath, outdir, scale=4):
+def render_pdf(inpath, outdir, scale):
     
     pdf = pdfjs.getDocument(str(inpath)).promise
     n_pages = pdf.numPages
@@ -51,7 +50,7 @@ def main():
     ResolvedPath = lambda p: Path(p).expanduser().resolve()
     parser.add_argument("inpath", type=ResolvedPath)
     parser.add_argument("--outdir", "-o", type=ResolvedPath)
-    parser.add_argument("--scale", type=float)
+    parser.add_argument("--scale", type=float, default=4)
     
     args = parser.parse_args()
     if not args.outdir.exists():

--- a/examples/python/pdfjs.py
+++ b/examples/python/pdfjs.py
@@ -17,9 +17,9 @@ pdfjs = javascript.require("pdfjs-dist")
 libcanvas = javascript.require("canvas")
 
 
-def render_pdf(inpath, outdir, scale):
+def render_pdf(input, outdir, scale):
     
-    pdf = pdfjs.getDocument(str(inpath)).promise
+    pdf = pdfjs.getDocument(input).promise
     n_pages = pdf.numPages
     n_digits = len(str(n_pages))
     
@@ -46,18 +46,23 @@ def render_pdf(inpath, outdir, scale):
 def main():
     
     parser = argparse.ArgumentParser(
-        description="Render a PDF file with Mozilla pdf.js via JsPyBridge",
+        description="Render a PDF file with Mozilla pdf.js via JsPyBridge.\n" +
+        "Known issues: - URL support is buggy; - certain PDFs may hit memory limits.",
     )
-    ResolvedPath = lambda p: Path(p).expanduser().resolve()
-    parser.add_argument("inpath", type=ResolvedPath)
-    parser.add_argument("--outdir", "-o", type=ResolvedPath)
+    path_type = lambda p: Path(p).expanduser().resolve()
+    input_type = lambda p: p if p.startswith("http") else str(path_type(p))
+    parser.add_argument(
+        "input", type=input_type,
+        help="Input file path or URL.",
+    )
+    parser.add_argument("--outdir", "-o", type=path_type)
     parser.add_argument("--scale", type=float, default=4)
     
     args = parser.parse_args()
     if not args.outdir.exists():
         args.outdir.mkdir(parents=True, exist_ok=True)
     
-    render_pdf(args.inpath, args.outdir, scale=args.scale)
+    render_pdf(args.input, args.outdir, scale=args.scale)
 
 
 main()

--- a/examples/python/pdfjs.py
+++ b/examples/python/pdfjs.py
@@ -33,6 +33,7 @@ def render_pdf(inpath, outdir, scale):
         context = canvas.getContext("2d")
         page.render({"canvasContext": context, "viewport": viewport}).promise
         
+        # note that blobValueOf() is much faster than valueOf()["data"] for large byte buffers
         js_buffer = canvas.toBuffer("raw")
         py_buffer = js_buffer.blobValueOf()
         

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -121,14 +121,14 @@ def writeAll(objs):
             break
 
 
-comm_items = []
+com_items = []
 
 # Reads from the socket, in this case it's standard error. Returns an array
 # of parsed responses from the server.
 def readAll():
-    global comm_items
-    capture = comm_items
-    comm_items = []
+    global com_items
+    capture = com_items
+    com_items = []
     return capture
 
 
@@ -170,7 +170,7 @@ def com_io():
     while proc.poll() is None:
         item = readComItem(proc.stderr)
         if item:
-            comm_items.append(item)
+            com_items.append(item)
             if config.event_loop != None:
                 config.event_loop.queue.put("stdin")
     stop()

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -83,7 +83,7 @@ def readComItem(stream):
         assert blob.endswith(b"\n")
         d["blob"] = blob[:-1]
         assert len(d["blob"]) == target_len
-        debug(f"[js -> py] blob r:{d['r']}: {d['blob'][:20]} ... {d['blob'][-20:]} (truncated)")
+        debug(f"[js -> py] blob r:{d['r']}: {d['blob'][:20]} ... (truncated)")
         
         return d
     

--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -174,7 +174,12 @@ class Bridge {
     const v = await this.m[ffid]
     this.ipc.send({ r, val: v.valueOf() })
   }
-
+  
+  async blob (r, ffid) {
+    const v = await this.m[ffid]
+    this.ipc.sendBlob(v, r)
+  }
+  
   async keys (r, ffid) {
     const v = await this.m[ffid]
     const keys = Object.getOwnPropertyNames(v)
@@ -251,6 +256,11 @@ const ipc = {
   send: data => {
     debug('js -> py', data)
     process.stderr.write(JSON.stringify(data) + '\n')
+  },
+  sendBlob: (data, r) => {
+    process.stderr.write('blob!{"r":'+r+',"len":'+data.length+'}!')
+    process.stderr.write(data)
+    process.stderr.write('\n')
   },
   writeRaw: (data, r, cb) => {
     debug('js -> py', data)

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -105,7 +105,7 @@ def test_blobValueOf_withNewLine():
     assert blob_value == bytes(json_value["data"]) == native_value
     
     # don't actually assert to avoid time dependent test case
-    print(f"blobValueOf() was factor {round(t_json/t_blob, 4)} faster than valueOf()")
+    print(f"blobValueOf() faster? {t_blob < t_json} (t_blob: {t_blob}, t_json {t_json})")
 
 
 def test_BlobValueOf_noNewLine():

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -90,9 +90,9 @@ def test_blobValueOf_generalValue():
     
     t_start = time.time()
     blob_value = js_buffer.blobValueOf()
+    t_blob = time.time() - t_start
     assert isinstance(blob_value, bytes)
     assert b"\n" in blob_value
-    t_blob = time.time() - t_start
     
     t_start = time.time()
     json_value = js_buffer.valueOf()

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -81,7 +81,7 @@ def test_valueOf():
     print("Array", demo.arr.valueOf())
 
 
-def test_blobValueOf_withNewLine():
+def test_blobValueOf_containingNLs():
     
     # use this file itself as test data for simplicity
     fs = require("fs")
@@ -109,15 +109,17 @@ def test_blobValueOf_withNewLine():
     print(f"blobValueOf() faster? {t_blob < t_json} (t_blob: {t_blob}, t_json {t_json})")
 
 
-def test_BlobValueOf_noNewLine():
-    input_value = "Test short value without new line."
-    # 'from' is a reserved keyword in python, so use dict getitem as a workaround
-    js_buffer = globalThis.Buffer["from"](input_value, "utf-8")
-    blob_value = js_buffer.blobValueOf()
-    assert b"\n" not in blob_value
-    json_value = js_buffer.valueOf()
-    assert json_value["type"] == "Buffer"
-    assert blob_value == bytes(json_value["data"]) == bytes(input_value, "utf-8")
+def test_BlobValueOf_noNL_and_paddingNLs():
+    test_values = ["Short test value without newline, or with padding newlines."]
+    for _ in range(2):
+        test_values.append("\n"+test_values[-1]+"\n")
+    for val in test_values:
+        # 'from' is a reserved keyword in python, so use dict getitem as a workaround
+        js_buffer = globalThis.Buffer["from"](val, "utf-8")
+        blob_value = js_buffer.blobValueOf()
+        json_value = js_buffer.valueOf()
+        assert json_value["type"] == "Buffer"
+        assert blob_value == bytes(json_value["data"]) == bytes(val, "utf-8")
 
 
 def test_once():
@@ -163,8 +165,8 @@ test_events()
 test_arrays()
 test_errors()
 test_valueOf()
-test_blobValueOf_withNewLine()
-test_BlobValueOf_noNewLine()
+test_blobValueOf_containingNLs()
+test_BlobValueOf_noNL_and_paddingNLs()
 test_once()
 test_assignment()
 test_eval()

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -113,7 +113,7 @@ def test_BlobValueOf_specificValues():
     test_values = [
         "Value without newline.",
         "\nValue with single enclosing newlines\n",
-        "\n\nTest with double enclosing newlines\n\n",
+        "\n\nValue with double enclosing newlines\n\n",
         "\n", "\n\n", "\n\n\n", "\n"*10,  # test various amounts of newlines only
     ]
     for val in test_values:

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -105,6 +105,7 @@ def test_blobValueOf_withNewLine():
     assert blob_value == bytes(json_value["data"]) == native_value
     
     # don't actually assert to avoid time dependent test case
+    # note, the performance difference is much more pronounced for bigger values (see examples/pdfjs.py)
     print(f"blobValueOf() faster? {t_blob < t_json} (t_blob: {t_blob}, t_json {t_json})")
 
 

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -109,14 +109,17 @@ def test_blobValueOf_generalValue():
     print(f"blobValueOf() faster? {t_blob < t_json} (t_blob: {t_blob}, t_json {t_json})")
 
 
-def test_BlobValueOf_specificValues():
+def test_blobValueOf_specificValues():
     test_values = [
-        "Value without newline.",
+        "Value without newline",
+        "Value with \nembedded\n newlines",
         "\nValue with single enclosing newlines\n",
         "\n\nValue with double enclosing newlines\n\n",
-        "\n", "\n\n", "\n\n\n", "\n"*10,  # test various amounts of newlines only
+        # test an empty string and various amounts of newlines only
+        "", *["\n"*c for c in (1, 2, 3, 10)]
     ]
     for val in test_values:
+        print(f"blobValueOf() {val!r}")
         # 'from' is a reserved keyword in python, so use dict getitem as a workaround
         js_buffer = globalThis.Buffer["from"](val, "utf-8")
         blob_value = js_buffer.blobValueOf()
@@ -169,7 +172,7 @@ test_arrays()
 test_errors()
 test_valueOf()
 test_blobValueOf_generalValue()
-test_BlobValueOf_specificValues()
+test_blobValueOf_specificValues()
 test_once()
 test_assignment()
 test_eval()

--- a/test/javascript/test_general.py
+++ b/test/javascript/test_general.py
@@ -81,7 +81,7 @@ def test_valueOf():
     print("Array", demo.arr.valueOf())
 
 
-def test_blobValueOf_containingNLs():
+def test_blobValueOf_generalValue():
     
     # use this file itself as test data for simplicity
     fs = require("fs")
@@ -109,10 +109,13 @@ def test_blobValueOf_containingNLs():
     print(f"blobValueOf() faster? {t_blob < t_json} (t_blob: {t_blob}, t_json {t_json})")
 
 
-def test_BlobValueOf_noNL_and_paddingNLs():
-    test_values = ["Short test value without newline, or with padding newlines."]
-    for _ in range(2):
-        test_values.append("\n"+test_values[-1]+"\n")
+def test_BlobValueOf_specificValues():
+    test_values = [
+        "Value without newline.",
+        "\nValue with single enclosing newlines\n",
+        "\n\nTest with double enclosing newlines\n\n",
+        "\n", "\n\n", "\n\n\n", "\n"*10,  # test various amounts of newlines only
+    ]
     for val in test_values:
         # 'from' is a reserved keyword in python, so use dict getitem as a workaround
         js_buffer = globalThis.Buffer["from"](val, "utf-8")
@@ -165,8 +168,8 @@ test_events()
 test_arrays()
 test_errors()
 test_valueOf()
-test_blobValueOf_containingNLs()
-test_BlobValueOf_noNL_and_paddingNLs()
+test_blobValueOf_generalValue()
+test_BlobValueOf_specificValues()
 test_once()
 test_assignment()
 test_eval()


### PR DESCRIPTION
This is a patch that would allow to transfer binary data (e.g. Buffer) directly from Js to Py, without JSON serialization, but using the existing stderr pipe mechanism (see #67).

Example on significance:
Rendering 10 PDF pages at ~200 DPI BGRX and transferring them via the existing `bytes(js_buffer.valueOf()["data"])` takes ~35s. The new `js_buffer.blobValueOf()` added here would reduce this to ~3s. (Interestingly enough, tempfiles are actually a bit faster than `blobValueOf()`.)

----

That said, I'm rather uncertain about the implementation. Blobs can't be handled using a simple separator (such as `\n`) but need to be passed with explicit length, which breaks `stderr_lines`.

This patch changes to immediate parsing (rather than deferred on `readAll()`) so we can fetch the remainder after the first `\n` to register a blob as a whole, instead of erroneously splitting into separate lines. — Is this OK? Any alternative ideas?

`readAll()` is now effectively a no-op, merely returning the prepared batch of items. I guess it should also be possible to feed the individual items into the queue directly?