### PR TITLE
Add None check for event_loop before adding to its queue.

### DIFF
--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -146,7 +146,8 @@ def com_io():
 
     while proc.poll() == None:
         stderr_lines.append(proc.stderr.readline())
-        config.event_loop.queue.put("stdin")
+        if config.event_loop != None:
+            config.event_loop.queue.put("stdin")
     stop()
 
 


### PR DESCRIPTION
Upon exit (in a PySide 6 project), the config.event_loop object is already set to None by the time that it hits this line in the code.

This results in an AttributeError: 'NoneType' object has no attribute 'queue' upon exit.

I patched this locally in my virtualenv and it has eliminated errors upon exit in my application.

Related to: #104 