### PR TITLE
javascript: don't try resolving path after installation, try import() directly

### DIFF
--- a/src/javascript/js/deps.js
+++ b/src/javascript/js/deps.js
@@ -83,7 +83,8 @@ class PackageManager {
       process.stderr.write('\n\n')
       process.stdout.write('\n')
       log('OK.')
-      return this.resolve(internalName)
+      // return this.resolve(internalName)
+      return internalName
     } else {
       // The package is already installed.
       return internalName


### PR DESCRIPTION
Fixes some issues with path resolution. Where as require() doesn't get updated after an npm install, it seems ESM import() does get updated, so we don't have to resolve the path manually to require it.