### PR TITLE
Update deprecated setDaemon

### DIFF
--- a/src/javascript/events.py
+++ b/src/javascript/events.py
@@ -24,7 +24,7 @@ class EventExecutorThread(threading.Thread):
 
     def __init__(self):
         super().__init__()
-        self.setDaemon(True)
+        self.daemon = True
 
     def add_job(self, request_id, cb_id, job, args):
         if request_id in self.doing:


### PR DESCRIPTION
.setDaemon got deprecated in Python 3.10, update to use .daemon property instead.
Read more [here](https://docs.python.org/3/library/threading.html#threading.Thread.daemon).