### PR TITLE
Minimal changes to allow manual re-initialization of NodeJS process

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -138,3 +138,40 @@ You can also use it inline.
 ```swift
 x_or_z = eval_js(''' obj.x ?? obj.z ''')
 ```
+
+### Controlling the NodeJS process
+
+By default, JSPyBridge spawns a single NodeJS process and all JavaScript calls are handled by it.
+It is possible to manually control this process in order to restore a clean NodeJS process, which
+can be used to clear memory and to recover from process crashes. The NodeJS process can be manually
+terminated and initialized with `terminate()` and `init()`, respectively, as shown in the following
+example:
+
+```py
+import javascript
+
+javascript.eval_js('console.log("Hello from 1st NodeJS process!")')
+javascript.terminate()
+
+javascript.init()
+javascript.eval_js('console.log("Hello from 2nd NodeJS process!")')
+javascript.terminate()
+```
+
+Note that the first NodeJS process does not need to be initialized manually. Thus, calling
+`javascript.init()` right after `import javascript` has no effect.
+
+#### Note about process re-initialization
+
+When re-initializing a NodeJS process with `javascript.init()`, please note that other exposed
+variables, such as `globalThis`, `console`, etc., are also re-assigned. In this case, it is
+recommended to access them using the full module import, as shown in the following example:
+
+```py
+import javascript # instead of `from javascript import globalThis`
+# ...
+now = javascript.globalThis.Date() # instead of `now = globalThis.Date()`
+```
+
+By doing this, `globalThis` is evaluated when called and will return a reference to the most
+recent NodeJS process, as expected.

--- a/src/javascript/__init__.py
+++ b/src/javascript/__init__.py
@@ -20,6 +20,11 @@ def init():
 init()
 
 
+def terminate():
+    if config.event_loop:
+        config.event_loop.stop()
+
+
 def require(name, version=None):
     calling_dir = None
     if name.startswith("."):

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -119,7 +119,6 @@ def writeAll(objs):
             proc.stdin.write(j.encode())
             proc.stdin.flush()
         except Exception:
-            stop()
             break
 
 
@@ -175,7 +174,6 @@ def com_io():
             com_items.append(item)
             if config.event_loop != None:
                 config.event_loop.queue.put("stdin")
-    stop()
 
 
 # FIXME untested

--- a/src/javascript/connection.py
+++ b/src/javascript/connection.py
@@ -112,13 +112,14 @@ def writeAll(objs):
         else:
             j = json.dumps(obj) + "\n"
         debug("[py -> js]", int(time.time() * 1000), j)
-        if not proc:
+        if not proc or proc.poll() is not None:
             sendQ.append(j.encode())
             continue
         try:
             proc.stdin.write(j.encode())
             proc.stdin.flush()
         except Exception:
+            stop()
             break
 
 
@@ -161,6 +162,7 @@ def com_io():
 
     for send in sendQ:
         proc.stdin.write(send)
+    sendQ.clear()
     proc.stdin.flush()
     
     # FIXME untested

--- a/src/javascript/events.py
+++ b/src/javascript/events.py
@@ -48,8 +48,6 @@ class EventLoop:
     queue = Queue()
     freeable = []
 
-    callbackExecutor = EventExecutorThread()
-
     # This contains a map of active callbacks that we're tracking.
     # As it's a WeakRef dict, we can add stuff here without blocking GC.
     # Once this list is empty (and a CB has been GC'ed) we can exit.
@@ -70,6 +68,7 @@ class EventLoop:
 
     def __init__(self):
         connection.start()
+        self.callbackExecutor = EventExecutorThread()
         self.callbackExecutor.start()
         self.pyi = pyi.PyInterface(self, config.executor)
 

--- a/src/javascript/events.py
+++ b/src/javascript/events.py
@@ -45,7 +45,6 @@ class EventExecutorThread(threading.Thread):
 # only one thread can run Python at a time, so no race conditions to worry about.
 class EventLoop:
     active = True
-    queue = Queue()
     freeable = []
 
     # This contains a map of active callbacks that we're tracking.
@@ -68,6 +67,7 @@ class EventLoop:
 
     def __init__(self):
         connection.start()
+        self.queue = Queue()
         self.callbackExecutor = EventExecutorThread()
         self.callbackExecutor.start()
         self.pyi = pyi.PyInterface(self, config.executor)


### PR DESCRIPTION
This PR aims to solve issue #130 by creating an interface to terminate and initialize the bridge's underlying NodeJS process and threads responsible for the communication.

To do this, I moved the calls responsible for referencing the bridge classes instances to the initialization function, refactored `EventLoop` and `EventExecutorThread`'s constructors to re-initialize its properties, changed the connection logic so it does not stop upon exception or process termination, and implemented a `terminate()` function in `__init__.py`.

With this change, the following behaviour is possible:
```py
import javascript

javascript.init()
javascript.eval_js('console.log("Hello from 1st NodeJS process!")')
javascript.terminate()

javascript.init()
javascript.eval_js('console.log("Hello from 2nd NodeJS process!")')
javascript.terminate()
```

Upon running this code, each time we `terminate()` and `init()`, a new NodeJS process is spawned and the bridge switches to communicate with it. Note that the first `eval_js` call can be done without calling `init()` because this function is called within the module's initialization. The function itself checks if the bridge has been previously initialized, so calling it again to ensure it is up is fine.

Most importantly, these changes should *not* break the current usage of the bridge. I have verified this by running `test.py` and `test_general.py`, and no exception is raised.

-----

I have only noticed one caveat about these changes regarding the global variables exposed by the module. When running the bridge interface after re-initializing the NodeJS process at least once, the following code does NOT work:
```py
from javascript import globalThis
# ...
print(globalThis.Date().toLocaleString())
```

However, this DOES work:
```py
import javascript
# ...
print(javascript.globalThis.Date().toLocaleString())
```

This is because the variable we get from `from javascript import globalThis` can only point to the global context of the first process as that's the reference that exists during the module import. On the other hand, calling `javascript.globalThis` can return the updated reference after the bridge re-initializes. I suspect this is also the case for `console` and `RegExp` as they are exposed with the same logic.

A cleaner way to solve this would be to write a getter for each of these variables and expose that instead of the references to variables themselves. For example, we can write in `__init__.py`:
```py
def get_global_this():
    return config.global_jsi.globalThis
```

This however would change the interface to the bridge (i.e., we would have to call `get_global_this().Date()` in the code above), therefore I did not commit it in this PR. Please let me know if this is desirable though.