### PR TITLE
fix: more graceful python shutdown

### DIFF
--- a/src/pythonia/IpcPipeCom.js
+++ b/src/pythonia/IpcPipeCom.js
@@ -45,7 +45,7 @@ class StdioCom {
   }
 
   end () {
-    this.proc.kill('SIGKILL')
+    this.proc.kill('SIGTERM')
     this.proc = null
   }
 

--- a/src/pythonia/interface.py
+++ b/src/pythonia/interface.py
@@ -14,11 +14,12 @@ class Ipc:
                 apiout.write(json.dumps(what) + "\n")
             apiout.flush()
         except Exception:
-            # Quit if we are unable to write (is the parent process dead?)
-            try:
-                sys.exit(1)
-            except Exception:
-                pass
+            if not sys.is_finalizing():
+                # Quit if we are unable to write (is the parent process dead?)
+                try:
+                    sys.exit(1)
+                except Exception:
+                    pass
 
 
 ipc = Ipc()


### PR DESCRIPTION
Tiny tweaks to make Python shutdown more graceful.

- `SIGTERM` rather than `SIGKILL` to allow Python `atexit` handlers, other signal handlers, and finalizers (ex. `finally`) to run before terminating.
- Added a finalization check to ensure the process doesn't try to exit while already exiting.

Without the last check, a runtime exception in the external Python triggered the following exception, caused because the `json` module is not guaranteed to still exist in the namespace :
```
Exception ignored in: <function Proxy.__del__ at 0x79bf799404c0>
Traceback (most recent call last):
  File "node_modules/pythonia/src/pythonia/proxy.py", line 226, in __del__
  File "node_modules/pythonia/src/pythonia/proxy.py", line 111, in free
  File "node_modules/pythonia/src/pythonia/Bridge.py", line 273, in queue_request
  File "node_modules/pythonia/src/pythonia/interface.py", line 19, in queue
SystemExit: 1
```