### PR TITLE
Fix ES5 class handling, allow disabling timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
-__*__
+__*
 .DS*
 src/**/package.json
 package-lock.json
 *.egg-info
+build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requires Node.js 18 and Python 3.8 or newer.
 * Object inspection allows you to easily `console.log` or `print()` any foreign objects
 * (Bridge to call Python from JS) Python class extension and inheritance. [See pytorch and tensorflow examples](https://github.com/extremeheat/JSPyBridge/blob/master/examples/javascript/pytorch-train.js).
 * (Bridge to call JS from Python) Native decorator-based event emitter support
-* (Bridge to call JS from Python) **First-class Jupyter Notebook/Google Colab support.** See some Google Colab uses below.
+* (Bridge to call JS from Python) First-class Jupyter Notebook/Google Colab support. See some Google Colab uses below.
 
 
 ## Basic usage example
@@ -300,7 +300,7 @@ for await (const file of files) {
 ```
 </details>
 
-## Details
+## Extra details
 
 * When doing a function call, any returned foreign objects will be sent to you as a reference. For example, if you're in JavaScript and do a function call to Python that returns an array, you won't get a JS array back, but you will get a reference to the Python array. You can still access the array normally with the [] notation, as long as you use await.
 
@@ -308,7 +308,7 @@ for await (const file of files) {
 
 * However, this does not apply with callbacks or non-native function input parameters. The bridge will try to serialize what it can, and will give you a foreign reference if it's unable to serialize something. So if you pass a JS object, you'll get a Python dict, but if the dict contains something like a class, you'll get a reference in its place.
 
-* If you would like the bridge to turn a foreign reference to something native, you can use `.valueOf()` to transfer an object via JSON serialization, or `.blobValueOf()` to write an object into the communication pipe directly.
+* (On the bridge to call JavaScript from Python) If you would like the bridge to turn a foreign reference to something native, you can use `.valueOf()` to transfer an object via JSON serialization, or `.blobValueOf()` to write an object into the communication pipe directly.
   - `.valueOf()` can be used on any JSON-serializable object, but may be very slow for big data.
   - `.blobValueOf()` can be used on any pipe-writeable object implementing the `length` property (e.g. `Buffer`). It can be massively faster by circumventing the JSON+UTF8 encode/decode layer, which is inept for large byte arrays.
 
@@ -322,4 +322,4 @@ for await (const file of files) {
 
 * On the bridge to call JavaScript from Python, due to the limiatations of Python and cross-platform IPC, we currently communicate over standard error which means that specific output in JS standard error can interfere with the bridge (as of this writing, the prefices `{"r"` and `blob!` are reserved). A similar issue exists on Windows with Python. You are however very unlikely to have issues with this.
 
-* Function calls will timeout after 100000 ms and throw a `BridgeException` error. That default value can be overridden by defining the new value of `REQ_TIMEOUT` in an environment variable.
+* Function calls will timeout after 100000 ms and throw a `BridgeException` error. That default value can be overridden by defining the new value of `REQ_TIMEOUT` in an environment variable, and setting it to 0 will disable timeout checks.

--- a/src/javascript/js/pyi.js
+++ b/src/javascript/js/pyi.js
@@ -38,7 +38,7 @@ class PythonException extends Error {
 
 async function waitFor (cb, withTimeout, onTimeout) {
   let t
-  if (withTimeout === Infinity) return new Promise(resolve => cb(resolve))
+  if ((withTimeout === Infinity) || (withTimeout === 0)) return new Promise(resolve => cb(resolve))
   const ret = await Promise.race([
     new Promise(resolve => cb(resolve)),
     new Promise(resolve => { t = setTimeout(() => resolve('timeout'), withTimeout) })

--- a/src/javascript/proxy.py
+++ b/src/javascript/proxy.py
@@ -176,20 +176,20 @@ class Executor:
         return self.bridge.m[ffid]
 
 
-INTERNAL_VARS = ["ffid", "_ix", "_exe", "_pffid", "_pname", "_es6", "_resolved", "_Keys"]
+INTERNAL_VARS = ["ffid", "_ix", "_exe", "_pffid", "_pname", "_Is_class", "_Resolved", "_Keys"]
 
 # "Proxy" classes get individually instanciated for every thread and JS object
 # that exists. It interacts with an Executor to communicate.
 class Proxy(object):
-    def __init__(self, exe, ffid, prop_ffid=None, prop_name="", es6=False):
+    def __init__(self, exe, ffid, prop_ffid=None, prop_name="", needs_init=False):
         self.ffid = ffid
         self._exe = exe
         self._ix = 0
         #
         self._pffid = prop_ffid if (prop_ffid != None) else ffid
         self._pname = prop_name
-        self._es6 = es6
-        self._resolved = {}
+        self._Is_class = needs_init
+        self._Resolved = {}
         self._Keys = None
 
     def _call(self, method, methodType, val):
@@ -199,7 +199,7 @@ class Proxy(object):
         if methodType == "fn":
             return Proxy(self._exe, val, self.ffid, method)
         if methodType == "class":
-            return Proxy(self._exe, val, es6=True)
+            return Proxy(self._exe, val, needs_init=True)
         if methodType == "obj":
             return Proxy(self._exe, val)
         if methodType == "inst":
@@ -214,7 +214,7 @@ class Proxy(object):
     def __call__(self, *args, timeout=10, forceRefs=False):
         mT, v = (
             self._exe.initProp(self._pffid, self._pname, args)
-            if self._es6
+            if self._Is_class
             else self._exe.callProp(
                 self._pffid, self._pname, args, timeout=timeout, forceRefs=forceRefs
             )
@@ -226,7 +226,7 @@ class Proxy(object):
     def __getattr__(self, attr):
         # Special handling for new keyword for ES5 classes
         if attr == "new":
-            return self._call(self._pname if self._pffid == self.ffid else "", "class", self._pffid)
+            return self._call(self._pname if self._pffid == self.ffid else "", "class", self.ffid)
         methodType, val = self._exe.getProp(self._pffid, attr)
         return self._call(attr, methodType, val)
 

--- a/src/javascript/proxy.py
+++ b/src/javascript/proxy.py
@@ -181,14 +181,14 @@ INTERNAL_VARS = ["ffid", "_ix", "_exe", "_pffid", "_pname", "_Is_class", "_Resol
 # "Proxy" classes get individually instanciated for every thread and JS object
 # that exists. It interacts with an Executor to communicate.
 class Proxy(object):
-    def __init__(self, exe, ffid, prop_ffid=None, prop_name="", needs_init=False):
+    def __init__(self, exe, ffid, prop_ffid=None, prop_name="", is_class=False):
         self.ffid = ffid
         self._exe = exe
         self._ix = 0
         #
         self._pffid = prop_ffid if (prop_ffid != None) else ffid
         self._pname = prop_name
-        self._Is_class = needs_init
+        self._Is_class = is_class
         self._Resolved = {}
         self._Keys = None
 
@@ -199,7 +199,7 @@ class Proxy(object):
         if methodType == "fn":
             return Proxy(self._exe, val, self.ffid, method)
         if methodType == "class":
-            return Proxy(self._exe, val, needs_init=True)
+            return Proxy(self._exe, val, is_class=True)
         if methodType == "obj":
             return Proxy(self._exe, val)
         if methodType == "inst":
@@ -226,7 +226,7 @@ class Proxy(object):
     def __getattr__(self, attr):
         # Special handling for new keyword for ES5 classes
         if attr == "new":
-            return self._call(self._pname if self._pffid == self.ffid else "", "class", self.ffid)
+            return Proxy(self._exe, self.ffid, self._pffid, self._pname, True)
         methodType, val = self._exe.getProp(self._pffid, attr)
         return self._call(attr, methodType, val)
 

--- a/src/pythonia/Bridge.js
+++ b/src/pythonia/Bridge.js
@@ -115,7 +115,7 @@ class PyClass {
 
 async function waitFor (cb, withTimeout, onTimeout) {
   let t
-  if (withTimeout === Infinity) return new Promise(resolve => cb(resolve))
+  if ((withTimeout === Infinity) || (withTimeout === 0)) return new Promise(resolve => cb(resolve))
   const ret = await Promise.race([
     new Promise(resolve => cb(resolve)),
     new Promise(resolve => { t = setTimeout(() => resolve('timeout'), withTimeout) })

--- a/src/pythonia/proxy.py
+++ b/src/pythonia/proxy.py
@@ -128,14 +128,14 @@ INTERNAL_VARS = ["ffid", "_ix", "_exe", "_pffid", "_pname", "_Is_class", "~class
 # "Proxy" classes get individually instanciated for every thread and JS object
 # that exists. It interacts with an Executor to communicate.
 class Proxy(object):
-    def __init__(self, exe, ffid, prop_ffid=None, prop_name="", needs_init=False):
+    def __init__(self, exe, ffid, prop_ffid=None, prop_name="", is_class=False):
         self.ffid = ffid
         self._exe = exe
         self._ix = 0
         #
         self._pffid = prop_ffid if (prop_ffid != None) else ffid
         self._pname = prop_name
-        self._Is_class = needs_init
+        self._Is_class = is_class
         self._Keys = None
 
     def _call(self, method, methodType, val):
@@ -145,7 +145,7 @@ class Proxy(object):
         if methodType == "fn":
             return Proxy(self._exe, val, self.ffid, method)
         if methodType == "class":
-            return Proxy(self._exe, val, needs_init=True)
+            return Proxy(self._exe, val, is_class=True)
         if methodType == "obj":
             return Proxy(self._exe, val)
         if methodType == "inst":
@@ -172,7 +172,7 @@ class Proxy(object):
     def __getattr__(self, attr):
         # Special handling for new keyword for ES5 classes
         if attr == "new":
-            return self._call(self._pname if self._pffid == self.ffid else "", "class", self.ffid)
+            return Proxy(self._exe, self.ffid, self._pffid, self._pname, True)
         methodType, val = self._exe.getProp(self._pffid, attr)
         return self._call(attr, methodType, val)
 


### PR DESCRIPTION
* Fix the `.new` python pseudo method to instantiate ES5 classes incorrectly passing prop FFID as opposed to current FFID
  * fix #136 
* Allow setting REQ_TIMEOUT to 0 to disable timeout checks