### PR TITLE
fix: npm package name resolution when using require with file paths from npm modules.

### DIFF
--- a/src/javascript/js/deps.js
+++ b/src/javascript/js/deps.js
@@ -125,10 +125,10 @@ async function $require (name, version, relativeTo) {
     // The user didn't specify a version. So try whatever version we find installed. This can fail for non CJS modules.
     try { return require(name) } catch { }
   }
-  if (name[0]=="@"){
-    [scope,name, ...path] = name.split('/')
+  if (name[0] == '@') {
+    [scope, name, ...path] = name.split('/')
     name = `${scope}/${name}`
-  }else{
+  } else {
     [name, ...path] = name.split('/') // for requiring files using from packages
   }
   // A version was specified, or the package wasn't found already installed.

--- a/src/javascript/js/deps.js
+++ b/src/javascript/js/deps.js
@@ -126,7 +126,7 @@ async function $require (name, version, relativeTo) {
   [name, ...path] = name.split('/') // for requiring files using from packages
   // A version was specified, or the package wasn't found already installed.
   const newpath = pm.install(name, version)
-  const mod = await import([newpath,...path].join('/'))
+  const mod = await import([newpath, ...path].join('/'))
   return mod.default ?? mod
 }
 

--- a/src/javascript/js/deps.js
+++ b/src/javascript/js/deps.js
@@ -123,10 +123,10 @@ async function $require (name, version, relativeTo) {
     // The user didn't specify a version. So try whatever version we find installed. This can fail for non CJS modules.
     try { return require(name) } catch { }
   }
-
+  [name, ...path] = name.split('/') // for requiring files using from packages
   // A version was specified, or the package wasn't found already installed.
   const newpath = pm.install(name, version)
-  const mod = await import(newpath)
+  const mod = await import([newpath,...path].join('/'))
   return mod.default ?? mod
 }
 

--- a/src/javascript/js/deps.js
+++ b/src/javascript/js/deps.js
@@ -1,6 +1,8 @@
 const cp = require('child_process')
 const fs = require('fs')
+const path = require('path')
 const { join } = require('path')
+const { sourceMapsEnabled } = require('process')
 const { pathToFileURL } = require('url')
 
 const NODE_PM = process.env.NODE_PM || 'npm'
@@ -123,7 +125,12 @@ async function $require (name, version, relativeTo) {
     // The user didn't specify a version. So try whatever version we find installed. This can fail for non CJS modules.
     try { return require(name) } catch { }
   }
-  [name, ...path] = name.split('/') // for requiring files using from packages
+  if (name[0]=="@"){
+    [scope,name, ...path] = name.split('/')
+    name = `${scope}/${name}`
+  }else{
+    [name, ...path] = name.split('/') // for requiring files using from packages
+  }
   // A version was specified, or the package wasn't found already installed.
   const newpath = pm.install(name, version)
   const mod = await import([newpath, ...path].join('/'))


### PR DESCRIPTION
To get npm package names for installing during first time from require statements with file paths.

Example
```js
require('mathjax-full/es5/tex-svg.js')
```