### PR TITLE
Handle non-Error objects thrown in JS

### DIFF
--- a/src/javascript/js/bridge.js
+++ b/src/javascript/js/bridge.js
@@ -117,7 +117,7 @@ class Bridge {
     try {
       this.m[ffid][attr] = val
     } catch (e) {
-      return this.ipc.send({ r, key: 'error', error: e.stack })
+      return this.ipc.send({ r, key: 'error', error: e.stack || JSON.stringify(e) })
     }
     this.ipc.send({ r, key: '', val: true })
   }
@@ -138,7 +138,7 @@ class Bridge {
         var v = await this.m[ffid](...args) // eslint-disable-line
       }
     } catch (e) {
-      return this.ipc.send({ r, key: 'error', error: e.stack })
+      return this.ipc.send({ r, key: 'error', error: e.stack || JSON.stringify(e) })
     }
     const type = getType(v)
     // console.log('GetType', type, v)
@@ -230,7 +230,7 @@ class Bridge {
       }
       await this[action](r, ffid, key, args)
     } catch (e) {
-      return this.ipc.send({ r, key: 'error', error: e.stack })
+      return this.ipc.send({ r, key: 'error', error: e.stack || JSON.stringify(e) })
     }
   }
 }

--- a/src/pythonia/jsi.js
+++ b/src/pythonia/jsi.js
@@ -92,7 +92,7 @@ class JSBridge {
     try {
       this.m[ffid][attr] = val
     } catch (e) {
-      return this.ipc.send({ r, key: 'error', error: e.stack })
+      return this.ipc.send({ r, key: 'error', error: e.stack || JSON.stringify(e) })
     }
     this.ipc.send({ r, key: '', val: true })
   }
@@ -113,7 +113,7 @@ class JSBridge {
         var v = await this.m[ffid](...args) // eslint-disable-line
       }
     } catch (e) {
-      return this.ipc.send({ r, key: 'error', error: e.stack })
+      return this.ipc.send({ r, key: 'error', error: e.stack || JSON.stringify(e) })
     }
     const type = getType(v)
     // console.log('GetType', type, v)
@@ -191,7 +191,7 @@ class JSBridge {
       }
       await this[action](r, ffid, key, args)
     } catch (e) {
-      return this.ipc.send({ r, key: 'error', error: e.stack })
+      return this.ipc.send({ r, key: 'error', error: e.stack || JSON.stringify(e) })
     }
   }
 }

--- a/test/javascript/test.js
+++ b/test/javascript/test.js
@@ -54,6 +54,10 @@ class DemoClass extends EventEmitter {
     throw Error('This should fail')
   }
 
+  error2 () {
+    throw {'non error': 'object'}
+  }
+
   ok () {
     function someMethod (a, b, c) {
       return a + b + c


### PR DESCRIPTION
.stack may not exist so just stringify the whole error object